### PR TITLE
Add executive coach and 360 review sections

### DIFF
--- a/index.html
+++ b/index.html
@@ -219,7 +219,7 @@
     <section id="plan-for-promotion" aria-labelledby="promotion-section">
       <div class="container grid-2">
         <div>
-          <h2 id="promotion-title">Plan for your next promotion.</h2>
+          <h2 id="promotion-title">Plan for your next promotion</h2>
           <p class="lead">Think through how your company will evaluate you and think through what's most important.</p>
           <ul class="list mt-3">
             <li>Think about whether your current work is on track to get you promoted.</li>
@@ -238,15 +238,15 @@
     <section id="executive-coach" aria-labelledby="executive-coach-title">
       <div class="container grid-2">
         <div>
-          <h2 id="executive-coach-title">It's like having an executive coach.</h2>
+          <h2 id="executive-coach-title">An affordable executive coach</h2>
           <p class="lead">Work Coach gives you senior-level partnership without the traditional coaching price tag or blind spots.</p>
         </div>
         <div>
           <ul class="list mt-2">
-            <li><strong>$25K engagements</strong> for 3–6 months become an always-on partner you can tap daily.</li>
+            <li><strong>$50 instead of $25,000</strong>— Exec coaching can cost $25,000 for a months long engagement with limited touchpoints.</li>
             <li><strong>Company context included</strong>—no need to teach an outsider your org, industry, or product from scratch.</li>
-            <li><strong>Continuous research</strong> instead of two meetings a month; the coach keeps pulling fresh insights for you.</li>
-            <li><strong>Unlimited context</strong>; AI reviews far more background than a human coach could ever keep up with.</li>
+            <li><strong>Continuous research</strong> instead of two meetings a month; the coach proactively sends fresh insights for you.</li>
+            <li><strong>Unlimited context</strong>— Coach can review all of your 1:1 transcripts, your whole performance review. More than a human coach could keep up with.</li>
           </ul>
         </div>
       </div>
@@ -255,14 +255,14 @@
     <section id="360-review" aria-labelledby="review-title">
       <div class="container grid-2">
         <div>
-          <h2 id="review-title">Work Coach runs your 360 review.</h2>
+          <h2 id="review-title">Get a 360 review</h2>
           <p class="lead">It gathers candid input, anonymizes the themes, and turns them into a clear picture of your strengths, blind spots, and next steps.</p>
         </div>
         <div>
           <ul class="list mt-2">
-            <li><strong>Interview above</strong>—leaders you report to share expectations and opportunities.</li>
-            <li><strong>Interview across</strong>—peers at your level surface collaboration wins and friction.</li>
-            <li><strong>Interview below</strong>—direct reports highlight how your leadership lands day to day.</li>
+            <li><strong>Interview your manager</strong>—understand how you are perceived by leadership.</li>
+            <li><strong>Interview your peers</strong>—your peers are the most important way to build consensus and influence.</li>
+            <li><strong>Interview your direct reports</strong>—understand what your direct reports won't say to your face.</li>
           </ul>
         </div>
       </div>
@@ -294,7 +294,7 @@
     <section id="why-different" aria-labelledby="diff-title">
       <div class="container grid-2">
         <div>
-          <h2 id="diff-title">The app is built for you.</h2>
+          <h2 id="diff-title">The app is built for you - not your company</h2>
           <ul class="list mt-2">
             <li><strong>Private</strong> — brings relevant playbooks/examples to you.</li>
             <li><strong>Company‑aware</strong> — learns your org, stakeholders, and norms.</li>
@@ -339,7 +339,7 @@
         </div>
         <div>
           <h2>Who it’s for</h2>
-          <p class="lead">PMs, engineers, and leaders who want executive‑level coaching without the executive‑level price—or calendar overhead.</p>
+          <p class="lead">PMs, engineers, marketers, designers, and leaders who want executive‑level coaching without the executive‑level price—or calendar overhead.</p>
         </div>
       </div>
     </section>

--- a/index.html
+++ b/index.html
@@ -235,6 +235,39 @@
       </div>
     </section>
 
+    <section id="executive-coach" aria-labelledby="executive-coach-title">
+      <div class="container grid-2">
+        <div>
+          <h2 id="executive-coach-title">It's like having an executive coach.</h2>
+          <p class="lead">Work Coach gives you senior-level partnership without the traditional coaching price tag or blind spots.</p>
+        </div>
+        <div>
+          <ul class="list mt-2">
+            <li><strong>$25K engagements</strong> for 3–6 months become an always-on partner you can tap daily.</li>
+            <li><strong>Company context included</strong>—no need to teach an outsider your org, industry, or product from scratch.</li>
+            <li><strong>Continuous research</strong> instead of two meetings a month; the coach keeps pulling fresh insights for you.</li>
+            <li><strong>Unlimited context</strong>; AI reviews far more background than a human coach could ever keep up with.</li>
+          </ul>
+        </div>
+      </div>
+    </section>
+
+    <section id="360-review" aria-labelledby="review-title">
+      <div class="container grid-2">
+        <div>
+          <h2 id="review-title">Work Coach runs your 360 review.</h2>
+          <p class="lead">It gathers candid input, anonymizes the themes, and turns them into a clear picture of your strengths, blind spots, and next steps.</p>
+        </div>
+        <div>
+          <ul class="list mt-2">
+            <li><strong>Interview above</strong>—leaders you report to share expectations and opportunities.</li>
+            <li><strong>Interview across</strong>—peers at your level surface collaboration wins and friction.</li>
+            <li><strong>Interview below</strong>—direct reports highlight how your leadership lands day to day.</li>
+          </ul>
+        </div>
+      </div>
+    </section>
+
     <section id="manage-up" aria-labelledby="manage-up-title">
       <div class="container grid-2">
         <div>


### PR DESCRIPTION
## Summary
- add an "executive coach" section highlighting how Work Coach compares to traditional coaching
- add a "360 review" section describing how feedback is gathered and anonymized for actionable insights

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cd659621a4832f926e7e6a0e36dcd1