### PR TITLE
Add Work Coach privacy policy page

### DIFF
--- a/index.html
+++ b/index.html
@@ -203,7 +203,7 @@
       <nav class="nav-links" aria-label="Primary">
         <a href="#how-it-works">How it works</a>
         <a href="#why-different">Why different</a>
-        <a href="#privacy">Privacy</a>
+        <a href="privacy.html">Privacy</a>
         <a href="#faq">FAQ</a>
         <a class="btn btn-primary" href="https://testflight.apple.com/join/m9fgUvak">Get the app</a>
       </nav>

--- a/privacy.html
+++ b/privacy.html
@@ -64,9 +64,9 @@
 
   <main>
     <div class="container card">
-      <p class="muted">Effective Date: September 30, 2025 • Last Updated: September 30, 2025</p>
+      <p class="muted">Effective Date: November 25, 2025 • Last Updated: November 25, 2025</p>
       <h1>Work Coach Privacy Policy</h1>
-      <p>Work Coach, Inc. ("Work Coach," "we," "us," or "our") provides AI-powered career and leadership coaching services. This Privacy Policy explains how we collect, use, disclose, and protect information when you use our website (getawork.coach), platform, and services (collectively, the "Services"). By using our Services, you acknowledge that you have read and understood this Privacy Policy and agree to our collection, use, and disclosure of your information as described herein.</p>
+      <p>Work Coach ("Work Coach," "we," "us," or "our") provides AI-powered career and leadership coaching services. This Privacy Policy explains how we collect, use, disclose, and protect information when you use our website (work.coach), platform, and services (collectively, the "Services"). By using our Services, you acknowledge that you have read and understood this Privacy Policy and agree to our collection, use, and disclosure of your information as described herein.</p>
       <p>Definition: Throughout this Privacy Policy, "Professional Development" or "Development" means improving your work-related skills and effectiveness through feedback and coaching provided by our Services.</p>
 
       <h2>1. Information We Collect</h2>
@@ -74,14 +74,12 @@
       <p><strong>Account Information</strong></p>
       <ul>
         <li>Name, email address, job title, role</li>
-        <li>Phone number (optional)</li>
         <li>Company/organization affiliation</li>
-        <li>Password and account credentials</li>
       </ul>
       <p><strong>Development Information</strong></p>
       <ul>
         <li>Development goals and focus areas</li>
-        <li>Optional context documents (resume, performance reviews)</li>
+        <li>Optional context documents (managers, performance reviews)</li>
         <li>Selection of feedback providers</li>
         <li>Coaching conversation content</li>
       </ul>
@@ -104,15 +102,13 @@
       </ul>
       <p><strong>Cookies and Analytics</strong></p>
       <ul>
-        <li>First-party cookies for session management</li>
-        <li>Analytics data (PostHog, Google Analytics)</li>
+        <li>Analytics data (PostHog)</li>
         <li>Session recordings (with sensitive content obscured)</li>
       </ul>
 
       <h3>1.3 Information from Third Parties</h3>
       <p>We may receive information about you from:</p>
       <ul>
-        <li>Your employer (if they sponsor your account)</li>
         <li>Feedback providers you select</li>
         <li>Third-party authentication services</li>
         <li>Business partners and service providers</li>
@@ -164,13 +160,7 @@
 
       <h2>3. How We Share Information</h2>
       <h3>3.1 With Organizations</h3>
-      <p>If your employer sponsors your account, they can see:</p>
-      <ul>
-        <li>Who was invited to provide feedback</li>
-        <li>Who has completed feedback sessions</li>
-        <li>Participation and completion rates</li>
-        <li>Aggregated, anonymized insights (minimum 5 participants)</li>
-      </ul>
+      <p>We do not share information with organizations (your employer, for example):</p>
       <p>They cannot see:</p>
       <ul>
         <li>Individual feedback content</li>
@@ -223,7 +213,7 @@
       <h2>5. Data Security</h2>
       <p>We implement administrative, technical, and physical safeguards designed to protect your information, including:</p>
       <ul>
-        <li>Encryption in transit and at rest</li>
+        <li>Encryption in transit</li>
         <li>Access controls and authentication</li>
         <li>Regular security assessments</li>
         <li>Employee training and confidentiality agreements</li>
@@ -272,7 +262,7 @@
         <li><strong>Right to Opt-Out:</strong> You may opt-out of the "sale" of personal information. Note: We do not sell personal information.</li>
         <li><strong>Right to Non-Discrimination:</strong> We will not discriminate against you for exercising your privacy rights.</li>
       </ul>
-      <p>To exercise these rights, contact <a href="mailto:privacy@getawork.coach">privacy@getawork.coach</a> or call [phone number].</p>
+      <p>To exercise these rights, contact <a href="mailto:support@work.coach">support@work.coach</a>.</p>
 
       <h2>8. Washington Privacy Rights</h2>
       <p>Washington residents have rights under the My Health My Data Act. While Work Coach is not a health service, we acknowledge that feedback may touch on well-being topics. We:</p>
@@ -293,7 +283,6 @@
 
       <h2>12. Data Ownership and Portability</h2>
       <p><strong>Individual Development Data:</strong> You retain access to your reports and insights regardless of employment status. Your Development journey belongs to you.</p>
-      <p><strong>Organization Rights:</strong> Organizations may request deletion of data related to their employees but cannot access confidential feedback content.</p>
       <p><strong>Data Portability:</strong> You may export your Development reports and insights at any time.</p>
 
       <h2>13. Automated Decision-Making</h2>
@@ -319,9 +308,8 @@
       <h2>16. How to Contact Us</h2>
       <p>For privacy-related questions or to exercise your rights:</p>
       <ul>
-        <li>Email: <a href="mailto:privacy@getawork.coach">privacy@getawork.coach</a></li>
-        <li>Support: <a href="mailto:support@getawork.coach">support@getawork.coach</a></li>
-        <li>Mail: Work Coach, Inc. [Address]</li>
+        <li>Email: <a href="mailto:support@work.coach">support@work.coach</a></li>
+        <li>Support: <a href="mailto:support@work.coach">support@work.coach</a></li>
       </ul>
       <p>Response time: We will acknowledge requests within 30 days and respond substantively within 45 days, with possible extension if needed.</p>
 
@@ -342,7 +330,7 @@
         <li>Legitimate Interests: For service improvement and security</li>
         <li>Legal Obligations: When required by law</li>
       </ul>
-      <p class="small muted">This Privacy Policy is effective as of September 12, 2025 and supersedes all previous versions.</p>
+      <p class="small muted">This Privacy Policy is effective as of November 25, 2025 and supersedes all previous versions.</p>
     </div>
   </main>
 

--- a/privacy.html
+++ b/privacy.html
@@ -1,0 +1,357 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
+  <meta name="description" content="Privacy Policy for Work Coach." />
+  <title>Work Coach — Privacy Policy</title>
+  <link rel="icon" href="img/favicon.ico">
+  <style>
+    *,*::before,*::after{box-sizing:border-box}
+    html,body{margin:0;padding:0}
+    body{
+      font-family: ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, "Apple Color Emoji", "Segoe UI Emoji";
+      line-height:1.6;
+      color:#0d1f14;
+      background:#f6fbf7;
+    }
+    a{color:inherit}
+    header{
+      position:sticky;top:0;z-index:10;
+      background:rgba(246,251,247,0.95);
+      border-bottom:1px solid #d7e4d9;
+      backdrop-filter:saturate(120%) blur(10px);
+    }
+    .container{
+      max-width:900px;
+      margin-inline:auto;
+      padding-left:max(20px, env(safe-area-inset-left));
+      padding-right:max(20px, env(safe-area-inset-right));
+    }
+    .nav{display:flex;align-items:center;justify-content:space-between;padding:16px 0;}
+    .brand{display:flex;align-items:center;gap:10px;font-weight:800;color:#0c2f1b;text-decoration:none}
+    .brand .dot{width:10px;height:10px;border-radius:50%;background:#31c178}
+    main{padding:40px 0 60px}
+    h1{font-size:clamp(1.8rem,3vw,2.4rem);margin:0 0 8px;color:#0c2f1b}
+    h2{margin-top:30px;font-size:1.1rem;color:#0c2f1b}
+    p,li{color:#0d1f14}
+    .muted{color:#4b6354}
+    .card{
+      background:#fff;
+      border:1px solid #d7e4d9;
+      border-radius:16px;
+      padding:24px;
+      box-shadow:0 10px 30px rgba(0,0,0,0.06);
+    }
+    ol{padding-left:20px}
+    ol li{margin-bottom:8px}
+    footer{padding:20px 0;color:#4b6354;border-top:1px solid #d7e4d9;text-align:center}
+    .small{font-size:.95rem}
+  </style>
+</head>
+<body>
+  <header>
+    <div class="container nav">
+      <a class="brand" href="./" aria-label="Work Coach home">
+        <span class="dot" aria-hidden="true"></span>
+        <span>Work Coach</span>
+      </a>
+      <nav aria-label="Secondary">
+        <a class="muted" href="index.html">Home</a>
+      </nav>
+    </div>
+  </header>
+
+  <main>
+    <div class="container card">
+      <p class="muted">Effective Date: September 30, 2025 • Last Updated: September 30, 2025</p>
+      <h1>Work Coach Privacy Policy</h1>
+      <p>Work Coach, Inc. ("Work Coach," "we," "us," or "our") provides AI-powered career and leadership coaching services. This Privacy Policy explains how we collect, use, disclose, and protect information when you use our website (getawork.coach), platform, and services (collectively, the "Services"). By using our Services, you acknowledge that you have read and understood this Privacy Policy and agree to our collection, use, and disclosure of your information as described herein.</p>
+      <p>Definition: Throughout this Privacy Policy, "Professional Development" or "Development" means improving your work-related skills and effectiveness through feedback and coaching provided by our Services.</p>
+
+      <h2>1. Information We Collect</h2>
+      <h3>1.1 Information You Provide Directly</h3>
+      <p><strong>Account Information</strong></p>
+      <ul>
+        <li>Name, email address, job title, role</li>
+        <li>Phone number (optional)</li>
+        <li>Company/organization affiliation</li>
+        <li>Password and account credentials</li>
+      </ul>
+      <p><strong>Development Information</strong></p>
+      <ul>
+        <li>Development goals and focus areas</li>
+        <li>Optional context documents (resume, performance reviews)</li>
+        <li>Selection of feedback providers</li>
+        <li>Coaching conversation content</li>
+      </ul>
+      <p><strong>Feedback Provider Information</strong></p>
+      <ul>
+        <li>Name and email address</li>
+        <li>Relationship to feedback recipient</li>
+        <li>Feedback content (via voice or text)</li>
+        <li>Voice recordings and transcripts</li>
+      </ul>
+
+      <h3>1.2 Information Collected Automatically</h3>
+      <p><strong>Usage Information</strong></p>
+      <ul>
+        <li>IP address and device information</li>
+        <li>Browser type and settings</li>
+        <li>Date, time, and duration of visits</li>
+        <li>Pages viewed and features used</li>
+        <li>Referring and exit pages</li>
+      </ul>
+      <p><strong>Cookies and Analytics</strong></p>
+      <ul>
+        <li>First-party cookies for session management</li>
+        <li>Analytics data (PostHog, Google Analytics)</li>
+        <li>Session recordings (with sensitive content obscured)</li>
+      </ul>
+
+      <h3>1.3 Information from Third Parties</h3>
+      <p>We may receive information about you from:</p>
+      <ul>
+        <li>Your employer (if they sponsor your account)</li>
+        <li>Feedback providers you select</li>
+        <li>Third-party authentication services</li>
+        <li>Business partners and service providers</li>
+      </ul>
+
+      <h2>2. How We Use Your Information</h2>
+      <h3>2.1 Primary Uses</h3>
+      <p>We use your information to:</p>
+      <ul>
+        <li>Provide and operate the Services</li>
+        <li>Conduct AI-powered feedback interviews</li>
+        <li>Generate 360 feedback reports and Development insights</li>
+        <li>Facilitate communication between users and feedback providers</li>
+        <li>Process payments and maintain accounts</li>
+      </ul>
+
+      <h3>2.2 Service Improvement</h3>
+      <p>We analyze aggregated, de-identified data to:</p>
+      <ul>
+        <li>Improve our AI interview techniques</li>
+        <li>Enhance feedback synthesis quality</li>
+        <li>Develop new features and services</li>
+        <li>Conduct research on Professional Development</li>
+      </ul>
+
+      <h3>2.3 AI and Machine Learning</h3>
+      <p><strong>What We Do:</strong></p>
+      <ul>
+        <li>Use AI to conduct voice interviews</li>
+        <li>Analyze feedback patterns and themes</li>
+        <li>Generate personalized Development insights</li>
+        <li>Improve our interview questions and synthesis</li>
+      </ul>
+      <p><strong>What We Don't Do:</strong></p>
+      <ul>
+        <li>Train third-party AI models (OpenAI, Anthropic) with your data</li>
+        <li>Use your personal feedback for other users</li>
+        <li>Create identifiable profiles for non-service purposes</li>
+      </ul>
+
+      <h3>2.4 Communications</h3>
+      <p>We may use your information to:</p>
+      <ul>
+        <li>Send service-related notifications</li>
+        <li>Respond to inquiries and support requests</li>
+        <li>Provide updates about new features (with consent)</li>
+        <li>Send marketing communications (with opt-out options)</li>
+      </ul>
+
+      <h2>3. How We Share Information</h2>
+      <h3>3.1 With Organizations</h3>
+      <p>If your employer sponsors your account, they can see:</p>
+      <ul>
+        <li>Who was invited to provide feedback</li>
+        <li>Who has completed feedback sessions</li>
+        <li>Participation and completion rates</li>
+        <li>Aggregated, anonymized insights (minimum 5 participants)</li>
+      </ul>
+      <p>They cannot see:</p>
+      <ul>
+        <li>Individual feedback content</li>
+        <li>Your Development report</li>
+        <li>Coaching conversations</li>
+        <li>Specific feedback from providers</li>
+      </ul>
+
+      <h3>3.2 With Service Providers</h3>
+      <p>We share information with third-party service providers who help us operate our Services:</p>
+      <ul>
+        <li>Cloud infrastructure providers</li>
+        <li>Communication services (email, SMS)</li>
+        <li>Payment processors</li>
+        <li>Analytics providers</li>
+        <li>AI/ML services</li>
+      </ul>
+      <p>All service providers are contractually bound to protect your information and use it only as directed by us.</p>
+
+      <h3>3.3 With Feedback Recipients</h3>
+      <p>Feedback providers should understand:</p>
+      <ul>
+        <li>Their feedback contributes to synthesized insights</li>
+        <li>Select quotes may be included for authenticity</li>
+        <li>Manager feedback is attributed by default</li>
+        <li>Other feedback is presented anonymously (solely on a “best efforts” basis; we cannot guarantee complete anonymity)</li>
+      </ul>
+
+      <h3>3.4 Legal Requirements</h3>
+      <p>We may disclose information when required by law or to:</p>
+      <ul>
+        <li>Comply with legal process</li>
+        <li>Protect rights, property, or safety</li>
+        <li>Enforce our Terms of Service</li>
+        <li>Respond to government requests</li>
+      </ul>
+
+      <h3>3.5 Business Transfers</h3>
+      <p>In the event of a merger, acquisition, or sale of assets, your information may be transferred to the acquiring entity.</p>
+
+      <h3>3.6 With Your Consent</h3>
+      <p>We may share information for any other purpose with your explicit consent.</p>
+
+      <h2>4. Data Retention</h2>
+      <p><strong>Voice Recordings:</strong> Deleted within 90 days of processing. This window allows for issue resolution throughout the entire 360 feedback process, including collection, synthesis, and report delivery.</p>
+      <p><strong>Transcripts and Reports:</strong> Retained while your account is active and for a reasonable period thereafter.</p>
+      <p><strong>Account Information:</strong> Retained until you request deletion or account is inactive for 24 months. This retention period enables long-term Development tracking and year-over-year progress comparison.</p>
+      <p><strong>Aggregated Data:</strong> May be retained indefinitely in de-identified form.</p>
+
+      <h2>5. Data Security</h2>
+      <p>We implement administrative, technical, and physical safeguards designed to protect your information, including:</p>
+      <ul>
+        <li>Encryption in transit and at rest</li>
+        <li>Access controls and authentication</li>
+        <li>Regular security assessments</li>
+        <li>Employee training and confidentiality agreements</li>
+      </ul>
+      <p>However, no method of transmission or storage is 100% secure. We cannot guarantee absolute security of your information.</p>
+
+      <h2>6. Your Rights and Choices</h2>
+      <h3>6.1 Access and Portability</h3>
+      <p>You may request:</p>
+      <ul>
+        <li>Access to your personal information</li>
+        <li>A copy of your 360 reports and insights</li>
+        <li>Export of your Development data</li>
+      </ul>
+
+      <h3>6.2 Correction and Deletion</h3>
+      <p>You may:</p>
+      <ul>
+        <li>Update your account information</li>
+        <li>Request correction of inaccuracies</li>
+        <li>Request deletion of your account and data</li>
+      </ul>
+      <p>Note: Some information may be retained for legal or legitimate business purposes.</p>
+
+      <h3>6.3 Communication Preferences</h3>
+      <p>You may:</p>
+      <ul>
+        <li>Opt-out of marketing emails</li>
+        <li>Adjust notification settings</li>
+        <li>Unsubscribe from non-essential communications</li>
+      </ul>
+
+      <h3>6.4 Feedback Provider Rights</h3>
+      <p>Feedback providers may:</p>
+      <ul>
+        <li>Supplement feedback before report generation</li>
+        <li>Create an account to manage multiple feedback requests</li>
+        <li>Contact us to request deletion before report finalization (exceptional cases)</li>
+      </ul>
+
+      <h2>7. California Privacy Rights</h2>
+      <p>California residents have additional rights under the California Consumer Privacy Act (CCPA) and California Privacy Rights Act (CPRA):</p>
+      <ul>
+        <li><strong>Right to Know:</strong> You may request information about the personal information we collect, use, and disclose.</li>
+        <li><strong>Right to Delete:</strong> You may request deletion of your personal information, subject to certain exceptions.</li>
+        <li><strong>Right to Opt-Out:</strong> You may opt-out of the "sale" of personal information. Note: We do not sell personal information.</li>
+        <li><strong>Right to Non-Discrimination:</strong> We will not discriminate against you for exercising your privacy rights.</li>
+      </ul>
+      <p>To exercise these rights, contact <a href="mailto:privacy@getawork.coach">privacy@getawork.coach</a> or call [phone number].</p>
+
+      <h2>8. Washington Privacy Rights</h2>
+      <p>Washington residents have rights under the My Health My Data Act. While Work Coach is not a health service, we acknowledge that feedback may touch on well-being topics. We:</p>
+      <ul>
+        <li>Do not sell health-related data</li>
+        <li>Will delete such information upon request</li>
+        <li>Obtain consent for processing any health-related information</li>
+      </ul>
+
+      <h2>9. International Data Transfers</h2>
+      <p>Work Coach is based in the United States and processes data on US servers. If you use our Services from outside the US, you consent to the transfer of your information to the US. We implement appropriate safeguards for international transfers, including standard contractual clauses where applicable.</p>
+
+      <h2>10. Children's Privacy</h2>
+      <p>Our Services are not intended for individuals under 18 years of age. We do not knowingly collect personal information from children under 18. If we learn we have collected information from a child under 18, we will delete it promptly.</p>
+
+      <h2>11. Special Information Regarding Sensitive Data</h2>
+      <p>Our AI coach focuses on workplace behaviors and performance. While personal characteristics may naturally arise in conversation, our system is designed to synthesize feedback around professional capabilities and growth areas. We do not intentionally collect special categories of personal information (race or ethnic origin, sex life or sexual orientation, criminal records, religion, political opinions, trade union membership, genetic/biometric data used for identification purposes, health conditions, etc.), and instruct users to focus on professional contexts.</p>
+
+      <h2>12. Data Ownership and Portability</h2>
+      <p><strong>Individual Development Data:</strong> You retain access to your reports and insights regardless of employment status. Your Development journey belongs to you.</p>
+      <p><strong>Organization Rights:</strong> Organizations may request deletion of data related to their employees but cannot access confidential feedback content.</p>
+      <p><strong>Data Portability:</strong> You may export your Development reports and insights at any time.</p>
+
+      <h2>13. Automated Decision-Making</h2>
+      <p>We use AI to analyze feedback and generate insights. These are recommendations for Professional Development, not automated decisions about you. All AI-generated content should be reviewed with human judgment and is not intended as the sole basis for employment decisions.</p>
+
+      <h2>14. Session Recording Disclosure</h2>
+      <p>We use analytics tools including session recording to improve our Services and debug issues. Session recordings automatically obscure:</p>
+      <ul>
+        <li>Feedback content and conversations</li>
+        <li>AI coach responses</li>
+        <li>Development reports and insights</li>
+      </ul>
+      <p>Recordings are retained for 90 days and accessible only to our technical team.</p>
+
+      <h2>15. Privacy Protection Thresholds</h2>
+      <p>To protect individual privacy:</p>
+      <ul>
+        <li>Minimum 3 feedback providers required to generate a report</li>
+        <li>Minimum 3 responses per category for category-specific insights</li>
+        <li>Minimum 5 participants for organizational aggregated insights</li>
+      </ul>
+
+      <h2>16. How to Contact Us</h2>
+      <p>For privacy-related questions or to exercise your rights:</p>
+      <ul>
+        <li>Email: <a href="mailto:privacy@getawork.coach">privacy@getawork.coach</a></li>
+        <li>Support: <a href="mailto:support@getawork.coach">support@getawork.coach</a></li>
+        <li>Mail: Work Coach, Inc. [Address]</li>
+      </ul>
+      <p>Response time: We will acknowledge requests within 30 days and respond substantively within 45 days, with possible extension if needed.</p>
+
+      <h2>17. Changes to This Privacy Policy</h2>
+      <p>We may update this Privacy Policy from time to time. We will notify you of material changes by:</p>
+      <ul>
+        <li>Posting the updated policy on our website</li>
+        <li>Sending notice to your registered email</li>
+        <li>Displaying a notice in the platform</li>
+      </ul>
+      <p>Your continued use after changes constitutes acceptance of the updated policy.</p>
+
+      <h2>18. Legal Basis for Processing (for EEA Users)</h2>
+      <p>We process personal data based on:</p>
+      <ul>
+        <li>Consent: For marketing and optional features</li>
+        <li>Contract: To provide Services you've requested</li>
+        <li>Legitimate Interests: For service improvement and security</li>
+        <li>Legal Obligations: When required by law</li>
+      </ul>
+      <p class="small muted">This Privacy Policy is effective as of September 12, 2025 and supersedes all previous versions.</p>
+    </div>
+  </main>
+
+  <footer>
+    <div class="container">© <span id="year"></span> Work Coach. All rights reserved.</div>
+  </footer>
+
+  <script>
+    document.getElementById('year').textContent = new Date().getFullYear();
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a dedicated privacy.html page containing the Work Coach privacy policy
- update site navigation to link to the new privacy policy page

## Testing
- not run (static content)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6925e0c2b980832fbad03fec4eaf7c26)