### PR TITLE
Update bio: left Reforge, focus on impact over roles

### DIFF
--- a/about.html
+++ b/about.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
-  <meta name="description" content="Dan Wolchonok is VP of New Products at Reforge with 20 years experience in product, growth, and analytics at HubSpot and other high-growth companies." />
+  <meta name="description" content="Dan Wolchonok has 20 years experience in product, growth, and analytics at HubSpot, Reforge, and other high-growth companies." />
   <meta name="color-scheme" content="light dark" />
   <title>About Dan Wolchonok | Work Coach</title>
   <link rel="icon" href="img/favicon.ico">
@@ -15,7 +15,7 @@
   <meta property="og:url" content="https://getawork.coach/about">
   <meta property="og:site_name" content="Work Coach">
   <meta property="og:title" content="About Dan Wolchonok | Work Coach">
-  <meta property="og:description" content="VP of New Products at Reforge. 20 years in product, growth, and analytics at high-growth tech companies.">
+  <meta property="og:description" content="20 years in product, growth, and analytics at high-growth tech companies including HubSpot and Reforge.">
   <meta property="og:image" content="https://getawork.coach/img/og-image.png">
   <meta property="og:image:width" content="1200">
   <meta property="og:image:height" content="630">
@@ -23,7 +23,7 @@
   <!-- Twitter / X -->
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="About Dan Wolchonok | Work Coach">
-  <meta name="twitter:description" content="VP of New Products at Reforge. 20 years in product, growth, and analytics at high-growth tech companies.">
+  <meta name="twitter:description" content="20 years in product, growth, and analytics at high-growth tech companies including HubSpot and Reforge.">
   <meta name="twitter:image" content="https://getawork.coach/img/og-image.png">
 
   <link href="https://fonts.googleapis.com/css2?family=Playfair+Display:ital,wght@0,400;0,600;1,400&family=Source+Sans+3:wght@400;500;600&display=swap" rel="stylesheet">
@@ -306,7 +306,7 @@
 
     .metrics-grid {
       display: grid;
-      grid-template-columns: repeat(4, 1fr);
+      grid-template-columns: repeat(3, 1fr);
       gap: 32px;
     }
 
@@ -655,7 +655,7 @@
       <div class="container">
         <p class="hero-kicker">Meet the founder</p>
         <h1>Dan <em>Wolchonok</em></h1>
-        <p class="hero-deck">VP of New Products at Reforge. 20 years building products and growth systems at high-growth technology companies.</p>
+        <p class="hero-deck">20 years building products and growth systems at high-growth technology companies.</p>
       </div>
     </section>
 
@@ -663,7 +663,7 @@
       <h2 id="content-title" class="sr-only">Background</h2>
       <div class="container">
         <div class="content-grid">
-          <p class="content-lead">Dan's career spans founding an acquired startup, five years at HubSpot driving product growth, and leadership roles at Reforge building the premier professional education platform for growth and product professionals.</p>
+          <p class="content-lead">Dan's career spans founding an acquired startup, five years at HubSpot on the founding team of HubSpot Sales, and seven years at Reforge helping scale the company from five employees to 180.</p>
           <div class="content-body">
             <p>After earning a <strong>Computer Science degree from Tufts University</strong>, Dan spent three years in <strong>management consulting at PwC</strong>, followed by three years at <strong>Microsoft as a Technical Lead</strong> working on enterprise search systems.</p>
             <p>In 2011, Dan enrolled at <strong>Yale School of Management</strong>. During his MBA, he founded PrepWork—a personal research assistant that was <strong>acquired by HubSpot in 2013</strong>, just nine months after founding.</p>
@@ -706,16 +706,12 @@
             <p class="metric-label">HubSpot Sales ARR<br>(founding team)</p>
           </div>
           <div class="metric">
-            <p class="metric-value">$81M</p>
-            <p class="metric-label">Reforge funding<br>(a16z, Insight Partners)</p>
+            <p class="metric-value">15x</p>
+            <p class="metric-label">Reforge revenue growth<br>($2M to $30M+)</p>
           </div>
           <div class="metric">
             <p class="metric-value">20</p>
             <p class="metric-label">Years in product,<br>growth &amp; analytics</p>
-          </div>
-          <div class="metric">
-            <p class="metric-value">2x</p>
-            <p class="metric-label">Email conversion lift<br>via AI personalization</p>
           </div>
         </div>
       </div>
@@ -726,22 +722,16 @@
         <h2 id="timeline-title">Career</h2>
         <div class="timeline-grid">
           <div class="timeline-item">
-            <p class="timeline-date">2024 — Present</p>
-            <h3>VP, New Products</h3>
-            <h4>Reforge</h4>
-            <p>Leading new product development at the premier professional education platform for growth and product professionals.</p>
-          </div>
-          <div class="timeline-item">
-            <p class="timeline-date">2018 — 2024</p>
-            <h3>Head of Data</h3>
-            <h4>Reforge</h4>
-            <p>Built the data team and infrastructure from scratch. Implemented AI-powered email personalization that doubled conversion rates.</p>
+            <p class="timeline-date">2018 — 2025</p>
+            <h3>Reforge</h3>
+            <h4>5th employee</h4>
+            <p>Helped scale from $2M to $30M+ in revenue and from 5 to 180 employees. Helped raise the Series A and Series B.</p>
           </div>
           <div class="timeline-item">
             <p class="timeline-date">2013 — 2018</p>
-            <h3>Director of Product Analytics</h3>
-            <h4>HubSpot</h4>
-            <p>Rose from PM to Director across five years. On the founding team of HubSpot Sales, now over $1 billion in ARR.</p>
+            <h3>HubSpot</h3>
+            <h4>Founding team, HubSpot Sales</h4>
+            <p>On the founding team of HubSpot Sales, now over $1 billion in ARR. Joined via acquisition of PrepWork.</p>
           </div>
           <div class="timeline-item">
             <p class="timeline-date">2012 — 2013</p>
@@ -779,10 +769,10 @@
           <div class="company-card">
             <h3>Reforge</h3>
             <ul class="company-stats">
-              <li><span class="stat-icon">$</span> <span><strong>$81M funding</strong> from Andreessen Horowitz, Insight Partners, TCV</span></li>
-              <li><span class="stat-icon">+</span> <span><strong>1,000+ teams</strong> using Reforge programs</span></li>
-              <li><span class="stat-icon">*</span> <span>Members from <strong>Google, Netflix, Airbnb, Spotify, Uber</strong></span></li>
-              <li><span class="stat-icon">!</span> <span>Rated <strong>"better than their MBA"</strong> by members</span></li>
+              <li><span class="stat-icon">5</span> <span><strong>5th employee</strong> at the company</span></li>
+              <li><span class="stat-icon">$</span> <span>Scaled from <strong>$2M to $30M+</strong> in revenue</span></li>
+              <li><span class="stat-icon">+</span> <span>Grew team from <strong>5 to 180 employees</strong></span></li>
+              <li><span class="stat-icon">%</span> <span>Helped raise <strong>Series A and Series B</strong></span></li>
             </ul>
           </div>
         </div>


### PR DESCRIPTION
- Remove current Reforge role (left in 2025)
- Update Reforge stats: 5th employee, $2M to $30M+ revenue, 5 to 180 employees, helped raise Series A and B
- Remove email conversion metric
- Consolidate timeline to focus on company impact, not titles
- Update metrics grid to 3 columns