### PR TITLE
Simplify career section, remove colleague quote

### DIFF
--- a/about.html
+++ b/about.html
@@ -375,77 +375,6 @@
       color: var(--muted);
     }
 
-    /* Companies section */
-    .companies {
-      padding: 100px 0;
-      background: var(--surface);
-      border-bottom: 1px solid var(--border);
-    }
-
-    .companies h2 {
-      font-family: 'Playfair Display', serif;
-      font-size: 36px;
-      font-weight: 400;
-      text-align: center;
-      margin-bottom: 80px;
-      color: var(--text);
-    }
-
-    .companies-grid {
-      display: grid;
-      grid-template-columns: 1fr 1fr;
-      gap: 48px;
-    }
-
-    @media (max-width: 768px) {
-      .companies-grid {
-        grid-template-columns: 1fr;
-      }
-    }
-
-    .company-card {
-      padding: 40px;
-      background: var(--card);
-      border: 1px solid var(--border);
-      border-radius: var(--radius);
-    }
-
-    .company-card h3 {
-      font-family: 'Playfair Display', serif;
-      font-size: 28px;
-      font-weight: 400;
-      margin-bottom: 24px;
-      color: var(--text);
-    }
-
-    .company-stats {
-      list-style: none;
-    }
-
-    .company-stats li {
-      padding: 12px 0;
-      border-bottom: 1px solid var(--border);
-      font-size: 15px;
-      color: var(--muted);
-      display: flex;
-      align-items: flex-start;
-      gap: 12px;
-    }
-
-    .company-stats li:last-child {
-      border-bottom: none;
-    }
-
-    .company-stats .stat-icon {
-      color: var(--accent);
-      font-weight: 700;
-      flex-shrink: 0;
-    }
-
-    .company-stats strong {
-      color: var(--text);
-    }
-
     /* Education section */
     .education {
       padding: 100px 0;
@@ -731,49 +660,13 @@
             <p class="timeline-date">2013 — 2018</p>
             <h3>HubSpot</h3>
             <h4>Founding team, HubSpot Sales</h4>
-            <p>On the founding team of HubSpot Sales, now over $1 billion in ARR. Joined via acquisition of PrepWork.</p>
+            <p>Pioneered product-led growth. On the founding team of HubSpot Sales, now over $1 billion in ARR. HubSpot grew from 600 to 2,600 employees during this time.</p>
           </div>
           <div class="timeline-item">
             <p class="timeline-date">2012 — 2013</p>
             <h3>Founder</h3>
             <h4>PrepWork (acquired by HubSpot)</h4>
             <p>Built a personal research assistant during Yale MBA. Acquired by HubSpot in nine months, before graduation.</p>
-          </div>
-        </div>
-      </div>
-    </section>
-
-    <section class="pullquote" aria-labelledby="pullquote-title">
-      <h2 id="pullquote-title" class="sr-only">Recognition</h2>
-      <div class="container">
-        <div class="pullquote-inner">
-          <blockquote>"One of the most pragmatic and tactical product managers—relentless in pursuit to improve high-value business metrics and a true champion of the customer."</blockquote>
-          <cite>Former colleague</cite>
-        </div>
-      </div>
-    </section>
-
-    <section class="companies" aria-labelledby="companies-title">
-      <div class="container">
-        <h2 id="companies-title">Company credentials</h2>
-        <div class="companies-grid">
-          <div class="company-card">
-            <h3>HubSpot</h3>
-            <ul class="company-stats">
-              <li><span class="stat-icon">$</span> <span><strong>$2.63 billion</strong> annual revenue (2024)</span></li>
-              <li><span class="stat-icon">%</span> <span><strong>2,100%+</strong> market cap growth since 2014 IPO</span></li>
-              <li><span class="stat-icon">#</span> <span><strong>247,939</strong> paying customers in 135+ countries</span></li>
-              <li><span class="stat-icon">1</span> <span><strong>#1 in marketing automation</strong> with 38% global market share</span></li>
-            </ul>
-          </div>
-          <div class="company-card">
-            <h3>Reforge</h3>
-            <ul class="company-stats">
-              <li><span class="stat-icon">5</span> <span><strong>5th employee</strong> at the company</span></li>
-              <li><span class="stat-icon">$</span> <span>Scaled from <strong>$2M to $30M+</strong> in revenue</span></li>
-              <li><span class="stat-icon">+</span> <span>Grew team from <strong>5 to 180 employees</strong></span></li>
-              <li><span class="stat-icon">%</span> <span>Helped raise <strong>Series A and Series B</strong></span></li>
-            </ul>
           </div>
         </div>
       </div>


### PR DESCRIPTION
- Remove colleague quote section
- Remove separate company credentials section
- Add HubSpot context: pioneered PLG, 600→2,600 employees
- Clean up unused CSS