### PR TITLE
Fix missing logo in Twitter link preview

### DIFF
--- a/360-feedback.html
+++ b/360-feedback.html
@@ -12,11 +12,11 @@
   <link rel="apple-touch-icon" href="img/apple-touch-icon.png">
   <!-- Open Graph -->
   <meta property="og:type" content="website">
-  <meta property="og:url" content="https://getawork.coach/360-feedback">
+  <meta property="og:url" content="https://work.coach/360-feedback">
   <meta property="og:site_name" content="Work Coach">
   <meta property="og:title" content="What Your Direct Reports Will Never Say | Work Coach">
   <meta property="og:description" content="Get the candid 360 feedback you need to grow as a leader.">
-  <meta property="og:image" content="https://getawork.coach/img/og-image.png">
+  <meta property="og:image" content="https://work.coach/img/og-image.png">
   <meta property="og:image:width" content="1200">
   <meta property="og:image:height" content="630">
 
@@ -24,7 +24,7 @@
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="What Your Direct Reports Will Never Say | Work Coach">
   <meta name="twitter:description" content="Get the candid 360 feedback you need to grow as a leader.">
-  <meta name="twitter:image" content="https://getawork.coach/img/og-image.png">
+  <meta name="twitter:image" content="https://work.coach/img/og-image.png">
 
   <!-- PostHog -->
   <script>

--- a/about.html
+++ b/about.html
@@ -12,11 +12,11 @@
   <link rel="apple-touch-icon" href="img/apple-touch-icon.png">
   <!-- Open Graph -->
   <meta property="og:type" content="website">
-  <meta property="og:url" content="https://getawork.coach/about">
+  <meta property="og:url" content="https://work.coach/about">
   <meta property="og:site_name" content="Work Coach">
   <meta property="og:title" content="About Dan Wolchonok | Work Coach">
   <meta property="og:description" content="20 years in product, growth, and analytics at high-growth tech companies including HubSpot and Reforge.">
-  <meta property="og:image" content="https://getawork.coach/img/og-image.png">
+  <meta property="og:image" content="https://work.coach/img/og-image.png">
   <meta property="og:image:width" content="1200">
   <meta property="og:image:height" content="630">
 
@@ -24,7 +24,7 @@
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="About Dan Wolchonok | Work Coach">
   <meta name="twitter:description" content="20 years in product, growth, and analytics at high-growth tech companies including HubSpot and Reforge.">
-  <meta name="twitter:image" content="https://getawork.coach/img/og-image.png">
+  <meta name="twitter:image" content="https://work.coach/img/og-image.png">
 
   <!-- PostHog -->
   <script>

--- a/index.html
+++ b/index.html
@@ -12,11 +12,11 @@
   <link rel="apple-touch-icon" href="img/apple-touch-icon.png">
   <!-- Open Graph -->
   <meta property="og:type" content="website">
-  <meta property="og:url" content="https://getawork.coach/">
+  <meta property="og:url" content="https://work.coach/">
   <meta property="og:site_name" content="Work Coach">
   <meta property="og:title" content="Work Coach: Your AI career coach.">
   <meta property="og:description" content="An affordable work coach in your pocket that is constantly thinking of how to help you.">
-  <meta property="og:image" content="https://getawork.coach/img/og-image.png">
+  <meta property="og:image" content="https://work.coach/img/og-image.png">
   <meta property="og:image:width" content="1200">
   <meta property="og:image:height" content="630">
   <meta property="og:image:alt" content="Coach whistle logo">
@@ -25,7 +25,7 @@
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="Work Coach: Your AI career coach.">
   <meta name="twitter:description" content="An affordable work coach in your pocket that is constantly thinking of how to help you.">
-  <meta name="twitter:image" content="https://getawork.coach/img/og-image.png">
+  <meta name="twitter:image" content="https://work.coach/img/og-image.png">
 
   <!-- PostHog -->
   <script>

--- a/manager-conversation.html
+++ b/manager-conversation.html
@@ -12,11 +12,11 @@
   <link rel="apple-touch-icon" href="img/apple-touch-icon.png">
   <!-- Open Graph -->
   <meta property="og:type" content="website">
-  <meta property="og:url" content="https://getawork.coach/manager-conversation">
+  <meta property="og:url" content="https://work.coach/manager-conversation">
   <meta property="og:site_name" content="Work Coach">
   <meta property="og:title" content="Talk to Your Manager About 360 Feedback | Work Coach">
   <meta property="og:description" content="How to tell your manager you're doing a 360 feedback cycle. Templates and talking points that reframe the conversation.">
-  <meta property="og:image" content="https://getawork.coach/img/og-image.png">
+  <meta property="og:image" content="https://work.coach/img/og-image.png">
   <meta property="og:image:width" content="1200">
   <meta property="og:image:height" content="630">
 
@@ -24,7 +24,7 @@
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="Talk to Your Manager About 360 Feedback | Work Coach">
   <meta name="twitter:description" content="How to tell your manager you're doing a 360 feedback cycle. Templates and talking points that reframe the conversation.">
-  <meta name="twitter:image" content="https://getawork.coach/img/og-image.png">
+  <meta name="twitter:image" content="https://work.coach/img/og-image.png">
 
   <!-- PostHog -->
   <script>


### PR DESCRIPTION
The meta tags were referencing getawork.coach but the site is hosted at work.coach, causing social media crawlers to fail when fetching the preview image.