### PR TITLE
Update meeting recording copy to be less phone-specific

### DIFF
--- a/index.html
+++ b/index.html
@@ -868,13 +868,13 @@
       <div class="container">
         <div class="section-header">
           <h2 id="recorder-title">Know how you actually show up in meetings</h2>
-          <p>Record from your phone. Get feedback no one else will give you.</p>
+          <p>Record your meetings. Get feedback no one else will give you.</p>
         </div>
         <div class="features">
           <div class="feature">
             <div class="feature-icon" aria-hidden="true">●</div>
-            <h3>Record from your phone</h3>
-            <p>Tap record and set your phone down. Your mic captures the meeting—no bots joining the call, no awkward notifications.</p>
+            <h3>Record your meetings</h3>
+            <p>Tap record and let your mic capture the meeting—no bots joining the call, no awkward notifications.</p>
             <p class="feature-detail">Works with in-person and virtual meetings alike</p>
           </div>
           <div class="feature">


### PR DESCRIPTION
Change "Record from your phone" to "Record your meetings" and remove
phone-specific language like "set your phone down" from the description.

https://claude.ai/code/session_01BsxGjPC5mngX7finSUCNp4