### PR TITLE
Update privacy policy with Google API data disclosure

### DIFF
--- a/privacy.html
+++ b/privacy.html
@@ -81,7 +81,7 @@
 
   <main>
     <div class="container card">
-      <p class="muted">Effective Date: November 25, 2025 • Last Updated: November 25, 2025</p>
+      <p class="muted">Effective Date: November 25, 2025 • Last Updated: February 22, 2026</p>
       <h1>Work Coach Privacy Policy</h1>
       <p>Work Coach ("Work Coach," "we," "us," or "our") provides AI-powered career and leadership coaching services. This Privacy Policy explains how we collect, use, disclose, and protect information when you use our website (work.coach), platform, and services (collectively, the "Services"). By using our Services, you acknowledge that you have read and understood this Privacy Policy and agree to our collection, use, and disclosure of your information as described herein.</p>
       <p>Definition: Throughout this Privacy Policy, "Professional Development" or "Development" means improving your work-related skills and effectiveness through feedback and coaching provided by our Services.</p>
@@ -348,6 +348,17 @@
         <li>Legitimate Interests: For service improvement and security</li>
         <li>Legal Obligations: When required by law</li>
       </ul>
+      <h2>19. Google User Data Disclosure</h2>
+      <p>Work Coach's use and transfer to any other app of information received from Google APIs will adhere to the <a href="https://developers.google.com/terms/api-services-user-data-policy">Google API Services User Data Policy</a>, including the Limited Use requirements.</p>
+      <p>Specifically:</p>
+      <ul>
+        <li>We only use Google user data (such as name, email address, and profile picture obtained through Google Sign-In) to provide and improve Work Coach's Services as described in this Privacy Policy.</li>
+        <li>We do not use Google user data for serving advertisements.</li>
+        <li>We do not sell Google user data to third parties.</li>
+        <li>We do not use Google user data for purposes unrelated to providing or improving Work Coach's Services.</li>
+        <li>Human access to Google user data is limited to what is necessary for security purposes, to comply with applicable law, or to provide and improve our Services, and only with the user's affirmative consent.</li>
+      </ul>
+
       <p class="small muted">This Privacy Policy is effective as of November 25, 2025 and supersedes all previous versions.</p>
     </div>
   </main>


### PR DESCRIPTION
## Summary
Updated the Work Coach privacy policy to include explicit disclosure regarding Google user data handling and compliance with Google API Services User Data Policy requirements.

## Key Changes
- Updated the "Last Updated" date from November 25, 2025 to February 22, 2026
- Added new section "19. Google User Data Disclosure" that outlines:
  - Adherence to Google API Services User Data Policy and Limited Use requirements
  - Clarification that Google user data is only used to provide and improve Work Coach's Services
  - Explicit statements that we do not use Google data for advertising or sell it to third parties
  - Confirmation that human access to Google user data is limited and requires user consent

## Implementation Details
The new section ensures transparency and compliance with Google's API policies by clearly communicating how Google Sign-In data (name, email, profile picture) is handled and protected. This addresses regulatory requirements and builds user trust regarding third-party data handling.

https://claude.ai/code/session_018pVqAwvmx6dTfWGvzSp5wS