### PR TITLE
Update meeting recording feature copy for clarity

### DIFF
--- a/index.html
+++ b/index.html
@@ -868,12 +868,12 @@
       <div class="container">
         <div class="section-header">
           <h2 id="recorder-title">Know how you actually show up in meetings</h2>
-          <p>Record your meetings. Get feedback no one else will give you.</p>
+          <p>Record yourself in meetings. Get feedback no one else will give you.</p>
         </div>
         <div class="features">
           <div class="feature">
             <div class="feature-icon" aria-hidden="true">●</div>
-            <h3>Record your meetings</h3>
+            <h3>Record yourself in meetings</h3>
             <p>Tap record and let your mic capture the meeting—no bots joining the call, no awkward notifications.</p>
             <p class="feature-detail">Works with in-person and virtual meetings alike</p>
           </div>


### PR DESCRIPTION
## Summary
Updated the messaging in the meeting recording feature section to be more precise and user-focused.

## Changes
- Updated the section subtitle from "Record your meetings" to "Record yourself in meetings" to clarify that users are recording their own participation
- Updated the feature heading with the same change for consistency

## Details
These copy changes improve clarity by explicitly stating that users are recording themselves rather than the entire meeting, which better sets expectations about the feature's scope and functionality.

https://claude.ai/code/session_01GMe9P5vNLYBXFqhj6vENMN