### PR TITLE
Add canonical URLs to all pages for SEO

### DIFF
--- a/360-feedback.html
+++ b/360-feedback.html
@@ -6,6 +6,7 @@
   <meta name="description" content="What your direct reports will never say to your face. Get the candid 360 feedback you need to grow as a leader." />
   <meta name="color-scheme" content="light dark" />
   <title>360 Feedback Cycles | Work Coach</title>
+  <link rel="canonical" href="https://work.coach/360-feedback" />
   <link rel="icon" href="img/favicon.ico">
   <link rel="icon" type="image/png" sizes="32x32" href="img/favicon-32.png">
   <link rel="icon" type="image/png" sizes="16x16" href="img/favicon-16.png">

--- a/about.html
+++ b/about.html
@@ -6,6 +6,7 @@
   <meta name="description" content="Dan Wolchonok has 20 years experience in product, growth, and analytics at HubSpot, Reforge, and other high-growth companies." />
   <meta name="color-scheme" content="light dark" />
   <title>About Dan Wolchonok | Work Coach</title>
+  <link rel="canonical" href="https://work.coach/about" />
   <link rel="icon" href="img/favicon.ico">
   <link rel="icon" type="image/png" sizes="32x32" href="img/favicon-32.png">
   <link rel="icon" type="image/png" sizes="16x16" href="img/favicon-16.png">

--- a/index.html
+++ b/index.html
@@ -6,6 +6,7 @@
   <meta name="description" content="Executive-level AI career coach in your pocket. Weekly voice sessions that turn your context into clear next steps—private, proactive, and built for builders." />
   <meta name="color-scheme" content="light dark" />
   <title>Work Coach — AI career coach.</title>
+  <link rel="canonical" href="https://work.coach/" />
   <link rel="icon" href="img/favicon.ico">
   <link rel="icon" type="image/png" sizes="32x32" href="img/favicon-32.png">
   <link rel="icon" type="image/png" sizes="16x16" href="img/favicon-16.png">

--- a/manager-conversation.html
+++ b/manager-conversation.html
@@ -6,6 +6,7 @@
   <meta name="description" content="How to tell your manager you're doing a 360 feedback cycle. Templates and talking points that reframe the conversation." />
   <meta name="color-scheme" content="light dark" />
   <title>Talk to Your Manager About 360 Feedback | Work Coach</title>
+  <link rel="canonical" href="https://work.coach/manager-conversation" />
   <link rel="icon" href="img/favicon.ico">
   <link rel="icon" type="image/png" sizes="32x32" href="img/favicon-32.png">
   <link rel="icon" type="image/png" sizes="16x16" href="img/favicon-16.png">

--- a/privacy.html
+++ b/privacy.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <meta name="description" content="Privacy Policy for Work Coach." />
   <title>Work Coach — Privacy Policy</title>
+  <link rel="canonical" href="https://work.coach/privacy" />
   <link rel="icon" href="img/favicon.ico">
   <style>
     *,*::before,*::after{box-sizing:border-box}

--- a/support.html
+++ b/support.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <meta name="description" content="Support for Work Coach." />
   <title>Work Coach — Support</title>
+  <link rel="canonical" href="https://work.coach/support" />
   <link rel="icon" href="img/favicon.ico">
   <style>
     *,*::before,*::after{box-sizing:border-box}


### PR DESCRIPTION
## Summary
Added canonical URL tags to all HTML pages to improve SEO and prevent duplicate content issues. Each page now includes a self-referential canonical link in the document head.

## Changes
- Added canonical URL to `index.html` (https://work.coach/)
- Added canonical URL to `360-feedback.html` (https://work.coach/360-feedback)
- Added canonical URL to `about.html` (https://work.coach/about)
- Added canonical URL to `manager-conversation.html` (https://work.coach/manager-conversation)
- Added canonical URL to `privacy.html` (https://work.coach/privacy)
- Added canonical URL to `support.html` (https://work.coach/support)

## Implementation Details
Each canonical link is placed in the `<head>` section immediately after the `<title>` tag, following standard SEO best practices. The canonical URLs use the absolute domain (https://work.coach) with the corresponding page path, helping search engines identify the preferred version of each page and consolidate ranking signals.

https://claude.ai/code/session_018GZ7UeYipXMnnSMvxLwmnc