### PR TITLE
Fix Apple icon alignment in Mac download button on non-index pages

### DIFF
--- a/360-feedback.html
+++ b/360-feedback.html
@@ -105,6 +105,9 @@
     }
 
     .nav-cta {
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
       padding: 10px 20px;
       background: var(--accent);
       color: var(--bg);
@@ -117,6 +120,12 @@
 
     .nav-cta:hover {
       background: color-mix(in oklab, var(--accent) 85%, white);
+    }
+
+    .apple-icon {
+      width: 16px;
+      height: 16px;
+      flex-shrink: 0;
     }
 
     .nav-links {

--- a/about.html
+++ b/about.html
@@ -105,6 +105,9 @@
     }
 
     .nav-cta {
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
       padding: 10px 20px;
       background: var(--accent);
       color: var(--bg);
@@ -117,6 +120,12 @@
 
     .nav-cta:hover {
       background: color-mix(in oklab, var(--accent) 85%, white);
+    }
+
+    .apple-icon {
+      width: 16px;
+      height: 16px;
+      flex-shrink: 0;
     }
 
     .nav-links {

--- a/manager-conversation.html
+++ b/manager-conversation.html
@@ -105,6 +105,9 @@
     }
 
     .nav-cta {
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
       padding: 10px 20px;
       background: var(--accent);
       color: var(--bg);
@@ -117,6 +120,12 @@
 
     .nav-cta:hover {
       background: color-mix(in oklab, var(--accent) 85%, white);
+    }
+
+    .apple-icon {
+      width: 16px;
+      height: 16px;
+      flex-shrink: 0;
     }
 
     .nav-links {


### PR DESCRIPTION
The .nav-cta class was missing display: inline-flex, align-items: center,
and gap: 8px, causing the Apple SVG icon to render incorrectly. Also added
the .apple-icon CSS class that was only defined in index.html.

https://claude.ai/code/session_01PdtLosHDSYXP7BRHGQWDgs