### PR TITLE
Remove HubSpot form submission integration

### DIFF
--- a/download.html
+++ b/download.html
@@ -976,12 +976,6 @@ footer {
   }
 
   // ─── Email forms ───
-  var HS_PORTAL = '240379';
-  var HS_FORMS = {
-    'mobile-form': '4ec96784-2317-4971-8a75-ee368eca1a39',
-    'windows-form': '7b9645bb-45eb-4417-9e1e-9ffb2780a505'
-  };
-
   function setupForm(formId, successId, eventName) {
     var form = document.getElementById(formId);
     var success = document.getElementById(successId);
@@ -989,29 +983,11 @@ footer {
     form.addEventListener('submit', function(e) {
       e.preventDefault();
       var input = form.querySelector('input[type="email"]');
-      var btn = form.querySelector('button');
       var email = input.value;
       if (!email) return;
-      btn.disabled = true;
-      btn.textContent = 'Sending...';
-
-      fetch('https://api.hsforms.com/submissions/v3/integration/submit/' + HS_PORTAL + '/' + HS_FORMS[formId], {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          fields: [{ name: 'email', value: email }],
-          context: { pageUri: window.location.href, pageName: document.title }
-        })
-      }).then(function(res) {
-        if (!res.ok) throw new Error('Submit failed');
-        posthog.capture(eventName, { email: email });
-        form.style.display = 'none';
-        success.classList.add('visible');
-      }).catch(function() {
-        btn.disabled = false;
-        btn.textContent = formId === 'mobile-form' ? 'Send me the link' : 'Notify me';
-        alert('Something went wrong. Please try again.');
-      });
+      posthog.capture(eventName, { email: email });
+      form.style.display = 'none';
+      success.classList.add('visible');
     });
   }
   setupForm('windows-form', 'windows-success', 'windows_waitlist_signup');


### PR DESCRIPTION
## Summary
Removed the HubSpot Forms API integration from the email signup forms, simplifying the form submission logic to only track events via PostHog without persisting email data to HubSpot.

## Key Changes
- Removed HubSpot portal ID and form UUID constants (`HS_PORTAL` and `HS_FORMS`)
- Removed the fetch request to HubSpot's submission API endpoint
- Removed button state management (disabled state and "Sending..." text)
- Simplified form submission to only capture PostHog events and show success message
- Removed error handling and retry logic for failed HubSpot submissions

## Implementation Details
The form submission now performs a minimal flow:
1. Validates email input
2. Captures event in PostHog for analytics
3. Hides the form and displays success message

Email addresses are no longer persisted to HubSpot, though they continue to be tracked via PostHog events.

https://claude.ai/code/session_016qTUqU9ZsTMiHCd4gBsigG