### PR TITLE
Add Google Ads tag and download conversion tracking

### DIFF
--- a/360-feedback.html
+++ b/360-feedback.html
@@ -1,6 +1,14 @@
 <!doctype html>
 <html lang="en">
 <head>
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=AW-1021884186"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+  gtag('config', 'AW-1021884186');
+</script>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <meta name="description" content="See yourself through the eyes of your team. Get the structured 360 feedback you need to grow as a leader." />

--- a/404.html
+++ b/404.html
@@ -1,6 +1,14 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=AW-1021884186"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+  gtag('config', 'AW-1021884186');
+</script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta name="robots" content="noindex">

--- a/about.html
+++ b/about.html
@@ -1,6 +1,14 @@
 <!doctype html>
 <html lang="en">
 <head>
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=AW-1021884186"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+  gtag('config', 'AW-1021884186');
+</script>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <meta name="description" content="Dan Wolchonok has 20 years experience in product, growth, and analytics at HubSpot, Reforge, and other high-growth companies." />

--- a/download.html
+++ b/download.html
@@ -1,6 +1,14 @@
 <!doctype html>
 <html lang="en">
 <head>
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=AW-1021884186"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+  gtag('config', 'AW-1021884186');
+</script>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
 <meta name="description" content="Download Work Coach for Mac. An AI coach that finds out what's holding you back.">
@@ -968,6 +976,17 @@ footer {
   console.log('[WorkCoach] platform:', navigator.platform);
   console.log('[WorkCoach] isMobile:', isMobile, 'isMac:', isMac, 'isWindows:', isWindows);
 
+  // ─── Google Ads conversion tracking ───
+  // Fires the conversion when a download is actually triggered (auto-redirect
+  // or manual link). Guarded so it never breaks the download if gtag is blocked.
+  function reportDownloadConversion() {
+    try {
+      if (typeof gtag === 'function') {
+        gtag('event', 'conversion', { 'send_to': 'AW-1021884186/zHfuCJ2g-rQcEJruoucD' });
+      }
+    } catch (e) {}
+  }
+
   if (isMobile) {
     console.log('[WorkCoach] Showing: mobile-view');
     document.getElementById('mobile-view').style.display = 'flex';
@@ -1093,6 +1112,7 @@ footer {
       if (countdownEl) countdownEl.textContent = countdown;
       if (countdown <= 0) {
         clearInterval(timer);
+        reportDownloadConversion();
         window.location.href = DOWNLOAD_URL;
       }
     }, 1000);
@@ -1100,6 +1120,7 @@ footer {
     // Manual download link
     document.getElementById('manual-download').addEventListener('click', function(e) {
       clearInterval(timer);
+      reportDownloadConversion();
       posthog.capture('download_manual_click');
     });
   }

--- a/index.html
+++ b/index.html
@@ -1,6 +1,14 @@
 <!doctype html>
 <html lang="en">
 <head>
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=AW-1021884186"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+  gtag('config', 'AW-1021884186');
+</script>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
 <meta name="description" content="An AI coach that finds out what's holding you back. Work Coach observes your meetings and gives you the feedback nobody tells you — filler words, missed agendas, coaching insights, and trends over time.">

--- a/macapp/checkout-cancel/index.html
+++ b/macapp/checkout-cancel/index.html
@@ -1,6 +1,14 @@
 <!doctype html>
 <html lang="en">
 <head>
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=AW-1021884186"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+  gtag('config', 'AW-1021884186');
+</script>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
 <meta name="robots" content="noindex">

--- a/macapp/checkout-success/index.html
+++ b/macapp/checkout-success/index.html
@@ -1,6 +1,14 @@
 <!doctype html>
 <html lang="en">
 <head>
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=AW-1021884186"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+  gtag('config', 'AW-1021884186');
+</script>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
 <meta name="robots" content="noindex">

--- a/macapp/index.html
+++ b/macapp/index.html
@@ -1,6 +1,14 @@
 <!doctype html>
 <html lang="en">
 <head>
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=AW-1021884186"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+  gtag('config', 'AW-1021884186');
+</script>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
 <meta name="robots" content="noindex">

--- a/manager-conversation.html
+++ b/manager-conversation.html
@@ -1,6 +1,14 @@
 <!doctype html>
 <html lang="en">
 <head>
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=AW-1021884186"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+  gtag('config', 'AW-1021884186');
+</script>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <meta name="description" content="How to pitch a 360 feedback cycle to your manager. A simple template that makes it easy for them to say yes." />

--- a/p/amplifyit.html
+++ b/p/amplifyit.html
@@ -1,6 +1,14 @@
 <!doctype html>
 <html lang="en">
 <head>
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=AW-1021884186"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+  gtag('config', 'AW-1021884186');
+</script>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
 <meta name="description" content="An AI coach that finds out what's holding you back. Work Coach observes your meetings and gives you the feedback nobody tells you — filler words, missed agendas, coaching insights, and trends over time.">

--- a/p/index.html
+++ b/p/index.html
@@ -1,6 +1,14 @@
 <!doctype html>
 <html lang="en">
 <head>
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=AW-1021884186"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+  gtag('config', 'AW-1021884186');
+</script>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
 <meta name="description" content="An AI coach that finds out what's holding you back. Work Coach observes your meetings and gives you the feedback nobody tells you — filler words, missed agendas, coaching insights, and trends over time.">

--- a/privacy.html
+++ b/privacy.html
@@ -1,6 +1,14 @@
 <!doctype html>
 <html lang="en">
 <head>
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=AW-1021884186"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+  gtag('config', 'AW-1021884186');
+</script>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <meta name="description" content="Privacy Policy for Work Coach." />

--- a/support.html
+++ b/support.html
@@ -1,6 +1,14 @@
 <!doctype html>
 <html lang="en">
 <head>
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=AW-1021884186"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+  gtag('config', 'AW-1021884186');
+</script>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <meta name="description" content="Support for Work Coach." />


### PR DESCRIPTION
## What this does

Adds Google Ads conversion tracking so paid ad campaigns can measure downloads.

### Changes
- **Google tag (gtag.js) on every page** — Installs the base tag for conversion ID `AW-1021884186` in the `<head>` of all 13 HTML pages (index, about, download, privacy, support, 404, `/p/*`, `/macapp/*`, etc.). Required everywhere so Google can attribute clicks before the conversion fires.
- **Conversion event on download** — On `/download`, fires `gtag('event', 'conversion', {...})` when a download is actually triggered, rather than on page view. The Mac flow downloads two ways and both are tracked:
  - the auto-redirect after the 3-second countdown
  - the "Download manually" link

  Both call a shared `reportDownloadConversion()` helper, wrapped in a `typeof gtag` guard + try/catch so it can never break the download if the tag is blocked (e.g. ad blockers).

### Notes
- Existing **PostHog** analytics is untouched — gtag runs alongside it.
- No **AMP** pages exist, so the AMP setup didn't apply.
- Windows/mobile visitors on `/download` only see a waitlist/email form (no actual download), so no conversion fires for them — which is correct.

https://claude.ai/code/session_013hsZjQe4EJhxQ5s1qCSndX

---
_Generated by [Claude Code](https://claude.ai/code/session_013hsZjQe4EJhxQ5s1qCSndX)_