### PR TITLE
Update pricing tiers: reduce Coach + Review and Coach + Live costs

### DIFF
--- a/index.html
+++ b/index.html
@@ -1775,7 +1775,7 @@ a:focus {
       <div class="price-eyebrow">AI + Human Review</div>
       <div class="price-name">Coach + Review</div>
       <p class="price-tagline">AI coaching, reviewed by a real human coach.</p>
-      <div class="price-amount"><span class="num">$500</span><span class="per">/ month</span></div>
+      <div class="price-amount"><span class="num">$250</span><span class="per">/ month</span></div>
       <ul class="price-features">
         <li class="price-feature"><span class="coach-check" aria-hidden="true"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg></span><span>Everything in Coach</span></li>
         <li class="price-feature"><span class="coach-check" aria-hidden="true"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg></span><span>A real human coach reviews your progress</span></li>
@@ -1804,7 +1804,7 @@ a:focus {
       <div class="price-eyebrow">AI + Live Coaching</div>
       <div class="price-name">Coach + Live</div>
       <p class="price-tagline">AI, human review, plus a coach in the room with you.</p>
-      <div class="price-amount"><span class="num">$1k</span><span class="per">/ month</span></div>
+      <div class="price-amount"><span class="num">$500</span><span class="per">/ month</span></div>
       <ul class="price-features">
         <li class="price-feature"><span class="coach-check" aria-hidden="true"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg></span><span>Everything in Coach + Review</span></li>
         <li class="price-feature"><span class="coach-check" aria-hidden="true"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg></span><span>A live monthly session with a work coach</span></li>
@@ -1825,7 +1825,7 @@ a:focus {
     </details>
     <details>
       <summary>Is there a real human coach?</summary>
-      <p>Yes — that's your choice. The base plan ($100/mo) is your always-on AI coach. Add human review of your progress ($500/mo), or a live monthly session with a real work coach ($1k/mo). You can change tiers anytime.</p>
+      <p>Yes — that's your choice. The base plan ($100/mo) is your always-on AI coach. Add human review of your progress ($250/mo), or a live monthly session with a real work coach ($500/mo). You can change tiers anytime.</p>
     </details>
     <details>
       <summary>Does a bot join my calls?</summary>
@@ -1849,7 +1849,7 @@ a:focus {
     </details>
     <details>
       <summary>What does it cost?</summary>
-      <p>Plans start at $100/month for the AI coach, $500/month to add human review, and $1k/month for live coaching sessions. Every plan starts with a 2-week free trial — no credit card required.</p>
+      <p>Plans start at $100/month for the AI coach, $250/month to add human review, and $500/month for live coaching sessions. Every plan starts with a 2-week free trial — no credit card required.</p>
     </details>
   </div>
 </section>


### PR DESCRIPTION
## Summary
This PR reduces the pricing for two premium coaching tiers to make them more accessible to customers.

## Changes
- **Coach + Review tier**: Reduced from $500/month to $250/month
- **Coach + Live tier**: Reduced from $1,000/month to $500/month
- Updated all pricing references in the FAQ section to reflect the new prices

## Details
The pricing updates are reflected in:
1. The pricing card for "Coach + Review" service
2. The pricing card for "Coach + Live" service
3. Two FAQ entries that mention pricing ("Is there a real human coach?" and "What does it cost?")

All pricing information is now consistent across the page.

https://claude.ai/code/session_01XPENdmULen2abVFnfokgPr