### PR TITLE
Reorder pricing cards to highlight Coach + Review as most popular

### DIFF
--- a/index.html
+++ b/index.html
@@ -1772,21 +1772,6 @@ a:focus {
   </div>
   <div class="pricing-grid">
     <div class="price-card">
-      <div class="price-eyebrow">AI + Human Review</div>
-      <div class="price-name">Coach + Review</div>
-      <p class="price-tagline">AI coaching, reviewed by a real human coach.</p>
-      <div class="price-amount"><span class="num">$250</span><span class="per">/ month</span></div>
-      <ul class="price-features">
-        <li class="price-feature"><span class="coach-check" aria-hidden="true"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg></span><span>Everything in Coach</span></li>
-        <li class="price-feature"><span class="coach-check" aria-hidden="true"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg></span><span>A real human coach reviews your progress</span></li>
-        <li class="price-feature"><span class="coach-check" aria-hidden="true"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg></span><span>Personalized feedback on your meetings</span></li>
-        <li class="price-feature"><span class="coach-check" aria-hidden="true"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg></span><span>Monthly written review from your coach</span></li>
-      </ul>
-      <a href="get-started" class="btn-outline btn-lg">Get Started</a>
-    </div>
-
-    <div class="price-card featured">
-      <span class="price-badge">Most popular</span>
       <div class="price-eyebrow">AI Coach</div>
       <div class="price-name">Coach</div>
       <p class="price-tagline">Your always-on AI coach that knows your meetings.</p>
@@ -1796,6 +1781,21 @@ a:focus {
         <li class="price-feature"><span class="coach-check" aria-hidden="true"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg></span><span>Voice conversations with your AI coach</span></li>
         <li class="price-feature"><span class="coach-check" aria-hidden="true"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg></span><span>Coaching across every goal</span></li>
         <li class="price-feature"><span class="coach-check" aria-hidden="true"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg></span><span>Accountability check-ins</span></li>
+      </ul>
+      <a href="get-started" class="btn-outline btn-lg">Get Started</a>
+    </div>
+
+    <div class="price-card featured">
+      <span class="price-badge">Most popular</span>
+      <div class="price-eyebrow">AI + Human Review</div>
+      <div class="price-name">Coach + Review</div>
+      <p class="price-tagline">AI coaching, reviewed by a real human coach.</p>
+      <div class="price-amount"><span class="num">$250</span><span class="per">/ month</span></div>
+      <ul class="price-features">
+        <li class="price-feature"><span class="coach-check" aria-hidden="true"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg></span><span>Everything in Coach</span></li>
+        <li class="price-feature"><span class="coach-check" aria-hidden="true"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg></span><span>A real human coach reviews your progress</span></li>
+        <li class="price-feature"><span class="coach-check" aria-hidden="true"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg></span><span>Personalized feedback on your meetings</span></li>
+        <li class="price-feature"><span class="coach-check" aria-hidden="true"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg></span><span>Monthly written review from your coach</span></li>
       </ul>
       <a href="get-started" class="btn-primary btn-lg">Get Started</a>
     </div>


### PR DESCRIPTION
## Summary
Reordered the pricing tier cards in the pricing section to promote the "Coach + Review" plan as the primary offering by moving it to the featured position with the "Most popular" badge.

## Key Changes
- Moved the "Coach + Review" pricing card from first position to second position
- Moved the "Coach" pricing card from second position to first position
- Transferred the "featured" class and "Most popular" badge from the "Coach" card to the "Coach + Review" card
- Updated the call-to-action button styling: "Coach" card now uses `btn-outline` while "Coach + Review" uses `btn-primary` to reflect the new hierarchy

## Implementation Details
- The "Coach + Review" tier ($250/month) is now visually emphasized as the recommended plan
- The "Coach" tier remains available as the entry-level option with a secondary button style
- No content changes were made; only the order and styling of existing pricing cards were modified

https://claude.ai/code/session_0113EjLRXr8fFhJjBdCLz53J