### PR TITLE
Sharpen use-case tab labels

### DIFF
--- a/index.html
+++ b/index.html
@@ -1288,31 +1288,31 @@ a:focus {
         <span class="usecase-icon" aria-hidden="true">
           <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="7" width="20" height="14" rx="2"/><path d="M16 7V5a2 2 0 0 0-2-2h-4a2 2 0 0 0-2 2v2"/></svg>
         </span>
-        <span class="usecase-tab-title">Get a job</span>
+        <span class="usecase-tab-title">Land your dream job</span>
       </button>
       <button type="button" class="usecase-tab" role="tab" aria-selected="false" aria-controls="uc-panel-promotion" id="uc-tab-promotion" data-target="promotion" tabindex="-1">
         <span class="usecase-icon" aria-hidden="true">
           <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="23 6 13.5 15.5 8.5 10.5 1 18"/><polyline points="17 6 23 6 23 12"/></svg>
         </span>
-        <span class="usecase-tab-title">Get a promotion</span>
+        <span class="usecase-tab-title">Get promoted</span>
       </button>
       <button type="button" class="usecase-tab" role="tab" aria-selected="false" aria-controls="uc-panel-team" id="uc-tab-team" data-target="team" tabindex="-1">
         <span class="usecase-icon" aria-hidden="true">
           <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"/><circle cx="9" cy="7" r="4"/><path d="M23 21v-2a4 4 0 0 0-3-3.87"/><path d="M16 3.13a4 4 0 0 1 0 7.75"/></svg>
         </span>
-        <span class="usecase-tab-title">Get more from your team</span>
+        <span class="usecase-tab-title">Become a better manager</span>
       </button>
       <button type="button" class="usecase-tab" role="tab" aria-selected="false" aria-controls="uc-panel-advocacy" id="uc-tab-advocacy" data-target="advocacy" tabindex="-1">
         <span class="usecase-icon" aria-hidden="true">
           <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M4 15s1-1 4-1 5 2 8 2 4-1 4-1V3s-1 1-4 1-5-2-8-2-4 1-4 1z"/><line x1="4" y1="22" x2="4" y2="15"/></svg>
         </span>
-        <span class="usecase-tab-title">Advocate for yourself</span>
+        <span class="usecase-tab-title">Get credit for your work</span>
       </button>
       <button type="button" class="usecase-tab" role="tab" aria-selected="false" aria-controls="uc-panel-confidence" id="uc-tab-confidence" data-target="confidence" tabindex="-1">
         <span class="usecase-icon" aria-hidden="true">
           <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2"/></svg>
         </span>
-        <span class="usecase-tab-title">Be more confident at work</span>
+        <span class="usecase-tab-title">Build real confidence</span>
       </button>
     </div>
     </div>


### PR DESCRIPTION
## Summary
Rewrite the five use-case tab labels to be more aspirational and outcome-focused:

| Before | After |
|---|---|
| Get a job | Land your dream job |
| Get a promotion | Get promoted |
| Get more from your team | Become a better manager |
| Advocate for yourself | Get credit for your work |
| Be more confident at work | Build real confidence |

(Cherry-picked from the pricing branch after #46 merged without it.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)