### PR TITLE
Add job-search use-case landing page

### DIFF
--- a/index.html
+++ b/index.html
@@ -1323,7 +1323,7 @@ a:focus {
           <div class="usecase-panel-eyebrow">For your job search</div>
           <h3>Get your dream job.</h3>
           <p>From the first application to the signed offer, your coach runs the whole search alongside you — and keeps you moving when momentum dips.</p>
-          <a href="#pricing" class="usecase-cta">See coaching plans →</a>
+          <a href="job-search" class="usecase-cta">See how the job search works →</a>
         </div>
         <div class="coach-card">
           <div class="coach-card-head">

--- a/job-search.html
+++ b/job-search.html
@@ -1,0 +1,1095 @@
+<!doctype html>
+<html lang="en">
+<head>
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=AW-1021884186"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+  gtag('config', 'AW-1021884186');
+</script>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+<meta name="description" content="A coach for your entire job search: résumé feedback, job description analysis, interview practice, real-interview review, and offer negotiation — all in one place.">
+<meta name="color-scheme" content="light">
+<title>Land Your Next Job | Work Coach</title>
+<link rel="canonical" href="https://work.coach/job-search">
+<link rel="icon" href="img/favicon.ico">
+<link rel="icon" type="image/png" sizes="32x32" href="img/favicon-32.png">
+<link rel="icon" type="image/png" sizes="16x16" href="img/favicon-16.png">
+<link rel="apple-touch-icon" href="img/apple-touch-icon.png">
+
+<meta property="og:type" content="website">
+<meta property="og:url" content="https://work.coach/job-search">
+<meta property="og:site_name" content="Work Coach">
+<meta property="og:title" content="Land Your Next Job | Work Coach">
+<meta property="og:description" content="Résumé feedback, interview prep tailored to the job description, practice reps, real-interview analysis, and negotiation help — one coach that runs the search with you.">
+<meta property="og:image" content="https://work.coach/img/og-image.png">
+<meta property="og:image:width" content="1200">
+<meta property="og:image:height" content="630">
+
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="Land Your Next Job | Work Coach">
+<meta name="twitter:description" content="Résumé feedback, interview prep tailored to the job description, practice reps, real-interview analysis, and negotiation help — one coach that runs the search with you.">
+<meta name="twitter:image" content="https://work.coach/img/og-image.png">
+
+<script>
+  !function(t,e){var o,n,p,r;e.__SV||(window.posthog=e,e._i=[],e.init=function(i,s,a){function g(t,e){var o=e.split(".");2==o.length&&(t=t[o[0]],e=o[1]),t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))}}(p=t.createElement("script")).type="text/javascript",p.crossOrigin="anonymous",p.async=!0,p.src=s.api_host.replace(".i.posthog.com","-assets.i.posthog.com")+"/static/array.js",(r=t.getElementsByTagName("script")[0]).parentNode.insertBefore(p,r);var u=e;for(void 0!==a?u=e[a]=[]:a="posthog",u.people=u.people||[],u.toString=function(t){var e="posthog";return"posthog"!==a&&(e+="."+a),t||(e+=" (stub)"),e},u.people.toString=function(){return u.toString(1)+".people (stub)"},o="init capture register register_once register_for_session unregister unregister_for_session getFeatureFlag getFeatureFlagPayload isFeatureEnabled reloadFeatureFlags updateEarlyAccessFeatureEnrollment getEarlyAccessFeatures on onFeatureFlags onSessionId getSurveys getActiveMatchingSurveys renderSurvey canRenderSurvey getNextSurveyStep identify setPersonProperties group resetGroups setPersonPropertiesForFlags resetPersonPropertiesForFlags setGroupPropertiesForFlags resetGroupPropertiesForFlags reset get_distinct_id getGroups get_session_id get_session_replay_url alias set_config startSessionRecording stopSessionRecording sessionRecordingStarted captureException loadToolbar get_property getSessionProperty createPersonProfile opt_in_capturing opt_out_capturing has_opted_in_capturing has_opted_out_capturing clear_opt_in_out_capturing debug".split(" "),n=0;n<o.length;n++)g(u,o[n]);e._i.push([i,s,a])},e.__SV=1)}(document,window.posthog||[]);
+  posthog.init('phc_1qX2rgCW83ghyqnBLTO6ZADUvTvceD36DwDochmrxfB',{api_host:'https://us.i.posthog.com', defaults:'2025-11-30'})
+</script>
+
+<link href="https://fonts.googleapis.com/css2?family=Playfair+Display:ital,wght@0,400;0,600;1,400&family=Source+Sans+3:wght@400;500;600;700&display=swap" rel="stylesheet">
+<style>
+*, *::before, *::after { margin: 0; padding: 0; box-sizing: border-box; }
+
+:root {
+  --bg: #f5f0e8;
+  --surface: #ebe5da;
+  --muted: #6b7a6e;
+  --text: #1a2e22;
+  --card: #fffdf8;
+  --border: #d6d0c4;
+  --accent: #31c178;
+  --accent-2: #1e6b42;
+  --accent-dark: #28a366;
+  --shadow: 0 10px 30px rgba(0,0,0,.07);
+  --radius: 16px;
+  --maxw: 1100px;
+  --amber: #c4891a;
+  --amber-soft: rgba(196, 137, 26, 0.1);
+  --red: #c94a4a;
+  --red-soft: rgba(201, 74, 74, 0.08);
+  --green-soft: rgba(49, 193, 120, 0.1);
+}
+
+html { scroll-behavior: smooth; }
+section[id] { scroll-margin-top: 88px; }
+body {
+  font-family: 'Source Sans 3', ui-sans-serif, system-ui, -apple-system, sans-serif;
+  background: var(--bg);
+  color: var(--text);
+  line-height: 1.7;
+  -webkit-font-smoothing: antialiased;
+}
+
+/* NAV */
+nav {
+  padding: 24px 0;
+  border-bottom: 1px solid var(--border);
+  position: sticky;
+  top: 0;
+  z-index: 50;
+  backdrop-filter: saturate(120%) blur(10px);
+  background: color-mix(in oklab, var(--bg) 85%, transparent);
+}
+.nav-inner {
+  max-width: var(--maxw);
+  margin: 0 auto;
+  padding: 0 max(20px, env(safe-area-inset-left));
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+.logo {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  font-weight: 800;
+  text-decoration: none;
+  color: var(--text);
+  font-size: 16px;
+}
+.logo-dot {
+  width: 10px; height: 10px;
+  background: var(--accent);
+  border-radius: 999px;
+  animation: pulse 2.5s ease-in-out infinite;
+}
+@keyframes pulse {
+  0%, 100% { opacity: 1; transform: scale(1); }
+  50% { opacity: 0.4; transform: scale(0.8); }
+}
+.nav-links {
+  display: flex; align-items: center; gap: 28px;
+}
+.nav-links a {
+  color: var(--muted);
+  text-decoration: none;
+  font-size: 15px;
+  font-weight: 500;
+  transition: color 0.2s;
+}
+.nav-links a:hover { color: var(--text); }
+.btn-primary {
+  display: inline-flex; align-items: center; gap: 8px;
+  padding: 10px 20px;
+  background: var(--accent);
+  color: #ffffff;
+  text-decoration: none;
+  font-size: 14px;
+  font-weight: 700;
+  border-radius: 999px;
+  font-family: 'Source Sans 3', sans-serif;
+  transition: background 0.2s;
+}
+.btn-primary:hover { background: color-mix(in oklab, var(--accent) 85%, white); }
+.btn-outline {
+  display: inline-flex; align-items: center; gap: 6px;
+  padding: 10px 20px;
+  background: transparent;
+  border: 1px solid var(--border);
+  color: var(--text);
+  text-decoration: none;
+  font-size: 14px;
+  font-weight: 600;
+  border-radius: 999px;
+  transition: border-color 0.2s;
+}
+.btn-outline:hover { border-color: color-mix(in oklab, var(--border) 50%, var(--accent) 50%); }
+.btn-lg { padding: 16px 32px; font-size: 15px; }
+
+/* HERO */
+.hero {
+  max-width: var(--maxw);
+  margin: 0 auto;
+  padding: 100px 20px 72px;
+  position: relative;
+  animation: fadeUp 0.7s ease-out;
+}
+.hero-inner {
+  max-width: 920px;
+  margin: 0 auto;
+  text-align: center;
+}
+.hero-kicker {
+  font-size: 13px;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  color: var(--accent);
+  margin-bottom: 20px;
+}
+.hero h1 {
+  font-family: 'Playfair Display', serif;
+  font-size: clamp(36px, 5vw, 60px);
+  font-weight: 400;
+  line-height: 1.12;
+  letter-spacing: -0.012em;
+  margin: 0 auto 18px;
+  max-width: 860px;
+}
+.hero h1 em { font-style: italic; color: var(--accent-2); }
+.hero .subtitle {
+  font-size: 21px;
+  color: color-mix(in oklab, var(--muted) 86%, white 14%);
+  max-width: 660px;
+  margin: 0 auto 34px;
+  line-height: 1.45;
+}
+.hero .cta-row {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 14px;
+  flex-wrap: wrap;
+  margin-bottom: 14px;
+}
+.hero .btn-primary.btn-lg {
+  padding: 17px 32px;
+  font-size: 18px;
+  box-shadow: 0 10px 26px rgba(49, 193, 120, 0.28);
+}
+.hero .fine-print { font-size: 13px; color: var(--muted); opacity: 0.6; }
+@keyframes fadeUp {
+  from { opacity: 0; transform: translateY(20px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+/* SECTION HEADERS */
+.section-label {
+  font-size: 13px;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  color: var(--accent);
+  text-align: center;
+  margin-bottom: 12px;
+}
+
+/* JOURNEY */
+.journey-section {
+  background: var(--surface);
+  border-top: 1px solid var(--border);
+  border-bottom: 1px solid var(--border);
+  padding: 80px 20px 88px;
+}
+.journey-head {
+  max-width: 720px;
+  margin: 0 auto 44px;
+  text-align: center;
+}
+.journey-head h2 {
+  font-family: 'Playfair Display', serif;
+  font-size: clamp(28px, 3.5vw, 38px);
+  font-weight: 400;
+  margin-bottom: 12px;
+}
+.journey-head p {
+  font-size: 16.5px;
+  color: var(--muted);
+  line-height: 1.6;
+}
+.journey-grid {
+  max-width: var(--maxw);
+  margin: 0 auto;
+  display: grid;
+  grid-template-columns: repeat(5, 1fr);
+  gap: 14px;
+}
+.journey-card {
+  display: block;
+  text-decoration: none;
+  color: inherit;
+  background: var(--card);
+  border: 1px solid var(--border);
+  border-radius: 14px;
+  padding: 20px 18px;
+  transition: border-color 0.2s, transform 0.2s, box-shadow 0.2s;
+}
+.journey-card:hover {
+  border-color: var(--accent-dark);
+  transform: translateY(-3px);
+  box-shadow: 0 12px 32px rgba(0,0,0,0.08);
+}
+.journey-n {
+  width: 28px; height: 28px;
+  border-radius: 999px;
+  background: var(--green-soft);
+  color: var(--accent-2);
+  font-weight: 700;
+  font-size: 13px;
+  display: grid;
+  place-items: center;
+  margin-bottom: 12px;
+}
+.journey-card h3 {
+  font-family: 'Playfair Display', serif;
+  font-size: 18.5px;
+  font-weight: 400;
+  line-height: 1.3;
+  margin-bottom: 6px;
+}
+.journey-card p {
+  font-size: 13.5px;
+  color: var(--muted);
+  line-height: 1.5;
+}
+.journey-card .journey-go {
+  display: inline-block;
+  margin-top: 10px;
+  font-size: 13px;
+  font-weight: 700;
+  color: var(--accent-2);
+}
+
+/* FEATURES */
+.feature-section { padding: 24px 20px 80px; }
+.feature-row {
+  max-width: 1020px;
+  margin: 0 auto;
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 56px;
+  align-items: center;
+  padding: 64px 0;
+  scroll-margin-top: 88px;
+}
+.feature-row + .feature-row { border-top: 1px solid var(--border); }
+.feature-row.reverse .feature-text { order: 2; }
+.feature-row.reverse .feature-visual { order: 1; }
+.feature-eyebrow {
+  font-size: 12px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--accent);
+  font-weight: 700;
+  margin-bottom: 10px;
+}
+.feature-text h3 {
+  font-family: 'Playfair Display', serif;
+  font-size: clamp(22px, 2.5vw, 28px);
+  font-weight: 400;
+  line-height: 1.3;
+  margin-bottom: 12px;
+}
+.feature-text p {
+  font-size: 15.5px;
+  color: var(--muted);
+  line-height: 1.7;
+}
+.feature-text p + p { margin-top: 12px; }
+.feature-visual {
+  background: var(--card);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  overflow: hidden;
+  box-shadow: var(--shadow);
+}
+
+/* Mock card internals */
+.wc-content { padding: 22px 24px 24px; }
+.wc-meeting-title {
+  font-family: 'Playfair Display', serif;
+  font-size: 18px;
+  font-weight: 400;
+  margin-bottom: 3px;
+}
+.wc-meta { font-size: 12px; color: var(--muted); opacity: 0.7; margin-bottom: 16px; }
+.wc-rec {
+  background: rgba(49, 193, 120, 0.08);
+  border: 1px solid var(--accent-dark);
+  border-radius: 10px;
+  padding: 14px 16px;
+  display: flex;
+  gap: 11px;
+  align-items: flex-start;
+}
+.wc-rec + .wc-rec { margin-top: 8px; }
+.wc-rec-icon {
+  width: 26px; height: 26px;
+  background: var(--accent);
+  border-radius: 7px;
+  display: flex; align-items: center; justify-content: center;
+  flex-shrink: 0;
+  margin-top: 1px;
+}
+.wc-rec-icon svg {
+  width: 14px; height: 14px;
+  fill: none;
+  stroke: var(--bg);
+  stroke-width: 2;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+.wc-rec-title {
+  font-size: 11px;
+  font-weight: 700;
+  color: var(--accent);
+  margin-bottom: 3px;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+.wc-rec-body { font-size: 13.5px; color: var(--muted); line-height: 1.55; }
+.wc-rec-link {
+  font-size: 12.5px;
+  color: var(--accent);
+  font-weight: 600;
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+}
+.wc-rec-actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-top: 8px;
+  flex-wrap: wrap;
+}
+.wc-rec-play {
+  font-size: 11px;
+  font-weight: 700;
+  color: var(--muted);
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  padding: 3px 10px;
+  font-variant-numeric: tabular-nums;
+}
+.wc-rec-secondary {
+  background: rgba(229, 168, 49, 0.06);
+  border-color: rgba(229, 168, 49, 0.25);
+}
+.wc-rec-secondary .wc-rec-icon { background: var(--amber); }
+.wc-rec-secondary .wc-rec-title { color: var(--amber); }
+.wc-rec-secondary .wc-rec-link { color: var(--amber); }
+
+.wc-stats-row {
+  display: flex;
+  gap: 6px;
+  margin-bottom: 14px;
+  flex-wrap: wrap;
+}
+.wc-stat-pill {
+  flex: 1;
+  min-width: 0;
+  padding: 10px 12px;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+}
+.wc-stat-pill .sp-label {
+  font-size: 10px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--muted);
+  margin-bottom: 3px;
+}
+.wc-stat-pill .sp-value {
+  font-family: 'Playfair Display', serif;
+  font-size: 18px;
+  font-weight: 600;
+  line-height: 1;
+}
+.wc-stat-pill .sp-value .unit {
+  font-size: 12px;
+  font-weight: 400;
+  color: var(--muted);
+}
+.wc-stat-pill .sp-detail {
+  font-size: 10.5px;
+  color: var(--muted);
+  opacity: 0.7;
+  margin-top: 2px;
+}
+
+/* Résumé review mock */
+.doc-line {
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  padding: 12px 14px;
+  background: var(--surface);
+}
+.doc-line + .doc-line { margin-top: 8px; }
+.doc-quote {
+  font-size: 13px;
+  color: var(--text);
+  font-style: italic;
+  line-height: 1.5;
+  margin-bottom: 6px;
+}
+.doc-note {
+  display: flex;
+  gap: 8px;
+  align-items: flex-start;
+  font-size: 12.5px;
+  line-height: 1.5;
+  color: var(--muted);
+}
+.doc-flag {
+  flex-shrink: 0;
+  font-size: 10px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  border-radius: 999px;
+  padding: 2px 9px;
+  margin-top: 1px;
+  white-space: nowrap;
+}
+.doc-flag.fix { background: var(--amber-soft); color: var(--amber); }
+.doc-flag.cut { background: var(--red-soft); color: var(--red); }
+.doc-flag.keep { background: var(--green-soft); color: var(--accent-2); }
+
+/* JD fit mock */
+.fit-cols {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 8px;
+  margin-bottom: 14px;
+}
+.fit-col {
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  padding: 12px 14px;
+  background: var(--surface);
+}
+.fit-col-title {
+  font-size: 10.5px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  margin-bottom: 8px;
+}
+.fit-col.strengths .fit-col-title { color: var(--accent-2); }
+.fit-col.gaps .fit-col-title { color: var(--amber); }
+.fit-col ul { list-style: none; display: grid; gap: 7px; }
+.fit-col li {
+  font-size: 12.5px;
+  color: var(--muted);
+  line-height: 1.45;
+  padding-left: 14px;
+  position: relative;
+}
+.fit-col li::before {
+  content: "";
+  position: absolute;
+  left: 0;
+  top: 7px;
+  width: 6px; height: 6px;
+  border-radius: 999px;
+}
+.fit-col.strengths li::before { background: var(--accent); }
+.fit-col.gaps li::before { background: var(--amber); }
+
+/* Interview question mock */
+.q-list { list-style: none; display: grid; gap: 8px; margin-bottom: 14px; }
+.q-item {
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  padding: 11px 14px;
+  background: var(--surface);
+}
+.q-tag {
+  display: inline-block;
+  font-size: 10px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--accent-2);
+  background: var(--green-soft);
+  border-radius: 999px;
+  padding: 2px 9px;
+  margin-bottom: 5px;
+}
+.q-tag.probe { color: var(--amber); background: var(--amber-soft); }
+.q-text { font-size: 13.5px; color: var(--text); line-height: 1.5; }
+
+/* Negotiation mock */
+.offer-rows { display: grid; gap: 9px; margin-bottom: 14px; }
+.offer-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 12px;
+  font-size: 13px;
+}
+.offer-label { color: var(--muted); }
+.offer-value {
+  font-weight: 600;
+  color: var(--text);
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+}
+.offer-value.up { color: var(--accent-2); }
+
+/* PULLQUOTE */
+.pullquote-section {
+  padding: 96px 20px;
+  border-top: 1px solid var(--border);
+  border-bottom: 1px solid var(--border);
+  background: var(--surface);
+}
+.pullquote-inner {
+  max-width: 800px;
+  margin: 0 auto;
+}
+.pullquote-inner h2 {
+  font-family: 'Playfair Display', serif;
+  font-size: clamp(26px, 3.5vw, 36px);
+  font-weight: 400;
+  line-height: 1.4;
+  margin-bottom: 24px;
+}
+.pullquote-inner p {
+  font-size: 16.5px;
+  color: var(--muted);
+  line-height: 1.7;
+  margin-bottom: 20px;
+}
+.pullquote-inner strong { color: var(--text); }
+
+/* FAQ */
+.faq-section {
+  padding: 96px 20px;
+  border-bottom: 1px solid var(--border);
+}
+.faq-section h2 {
+  font-family: 'Playfair Display', serif;
+  font-size: 36px;
+  font-weight: 400;
+  text-align: center;
+  margin-bottom: 60px;
+}
+.faq-grid {
+  max-width: 800px;
+  margin: 0 auto;
+}
+details {
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 20px 24px;
+  background: var(--card);
+  margin-bottom: 16px;
+}
+details summary {
+  cursor: pointer;
+  font-weight: 600;
+  font-size: 17px;
+  color: var(--text);
+  list-style: none;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+details summary::-webkit-details-marker { display: none; }
+details summary::after {
+  content: "+";
+  font-size: 24px;
+  color: var(--accent);
+  font-weight: 400;
+}
+details[open] summary::after { content: "−"; }
+details p {
+  margin-top: 16px;
+  color: var(--muted);
+  font-size: 15px;
+  line-height: 1.7;
+}
+
+/* CTA */
+.cta-section {
+  text-align: center;
+  padding: 120px 20px;
+}
+.cta-section h2 {
+  font-family: 'Playfair Display', serif;
+  font-size: clamp(32px, 5vw, 48px);
+  font-weight: 400;
+  margin-bottom: 16px;
+}
+.cta-section p {
+  font-size: 18px;
+  color: var(--muted);
+  max-width: 460px;
+  margin: 0 auto 40px;
+}
+.cta-section .cta-row {
+  display: flex;
+  justify-content: center;
+  gap: 16px;
+  flex-wrap: wrap;
+  margin-bottom: 16px;
+}
+.cta-section .fine-print { font-size: 13px; color: var(--muted); opacity: 0.6; }
+
+/* FOOTER */
+footer {
+  padding: 32px 0;
+  background: var(--bg);
+  border-top: 1px solid var(--border);
+}
+.footer-inner {
+  max-width: var(--maxw);
+  margin: 0 auto;
+  padding: 0 20px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 16px;
+}
+footer p { color: var(--muted); font-size: 14px; }
+.footer-links { display: flex; gap: 24px; }
+.footer-links a { color: var(--muted); text-decoration: none; font-size: 14px; transition: color 0.2s; }
+.footer-links a:hover { color: var(--text); }
+
+/* ACCESSIBILITY */
+.sr-only {
+  position: absolute;
+  left: -10000px;
+  top: auto;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  clip: rect(1px, 1px, 1px, 1px);
+  clip-path: inset(50%);
+  white-space: nowrap;
+}
+.sr-only:focus, .sr-only:active {
+  left: 16px;
+  top: 12px;
+  width: auto;
+  height: auto;
+  overflow: visible;
+  clip: auto;
+  clip-path: none;
+  white-space: normal;
+  z-index: 1000;
+  padding: 8px 12px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--surface);
+  color: var(--text);
+  outline: 2px solid color-mix(in oklab, var(--accent) 60%, white);
+  outline-offset: 2px;
+  box-shadow: var(--shadow);
+}
+a:focus {
+  outline: 2px solid color-mix(in oklab, var(--accent) 60%, white);
+  outline-offset: 2px;
+}
+
+/* MOBILE */
+@media (max-width: 768px) { .nav-links { display: none; } }
+@media (max-width: 920px) {
+  .journey-grid { grid-template-columns: repeat(2, 1fr); }
+  .journey-card:last-child { grid-column: 1 / -1; }
+}
+@media (max-width: 600px) {
+  .hero { padding: 80px 20px 60px; }
+  .hero .subtitle { font-size: 17px; max-width: 340px; }
+  .journey-grid { grid-template-columns: 1fr; }
+  .journey-card:last-child { grid-column: auto; }
+  .feature-row, .feature-row.reverse { grid-template-columns: 1fr; gap: 32px; padding: 48px 0; }
+  .feature-row.reverse .feature-text { order: 1; }
+  .feature-row.reverse .feature-visual { order: 2; }
+  .fit-cols { grid-template-columns: 1fr; }
+  .hero .cta-row, .cta-section .cta-row { flex-direction: column; gap: 10px; }
+}
+</style>
+</head>
+<body>
+<a class="sr-only" href="#main">Skip to content</a>
+
+<nav>
+  <div class="nav-inner">
+    <a href="/" class="logo"><span class="logo-dot"></span> Work Coach</a>
+    <div class="nav-links">
+      <a href="#journey">How it works</a>
+      <a href="#features">What you get</a>
+      <a href="/#pricing">Pricing</a>
+      <a href="#faq">FAQ</a>
+    </div>
+    <a href="https://my.work.coach" class="btn-primary">Start Free Trial</a>
+  </div>
+</nav>
+
+<main id="main">
+<section class="hero">
+  <div class="hero-inner">
+    <p class="hero-kicker">For your job search</p>
+    <h1>The whole job search, <em>coached</em> — from résumé to signed offer.</h1>
+    <p class="subtitle">Sharpen your résumé, decode every job description, practice the interview before it counts, learn from the real ones, and negotiate like you've done it a hundred times.</p>
+    <div class="cta-row">
+      <a href="https://my.work.coach" class="btn-primary btn-lg">Start Free Trial</a>
+      <a href="#features" class="btn-outline btn-lg">See what your coach does</a>
+    </div>
+    <p class="fine-print">2-week free trial · No credit card · Your data stays yours</p>
+  </div>
+</section>
+
+<section class="journey-section" id="journey">
+  <div class="journey-head">
+    <div class="section-label">One coach, five stages</div>
+    <h2>Most people run their search alone. You won't.</h2>
+    <p>Every stage of the search is a skill — and every one of them is coachable. Work Coach stays with you from the first application to the signed offer.</p>
+  </div>
+  <div class="journey-grid">
+    <a class="journey-card" href="#resume">
+      <span class="journey-n">1</span>
+      <h3>Sharpen your résumé</h3>
+      <p>Line-by-line feedback on what to fix, cut, and quantify.</p>
+      <span class="journey-go">Learn more →</span>
+    </a>
+    <a class="journey-card" href="#job-description">
+      <span class="journey-n">2</span>
+      <h3>Decode the job description</h3>
+      <p>See the role through the hiring manager's eyes — your strengths and your gaps.</p>
+      <span class="journey-go">Learn more →</span>
+    </a>
+    <a class="journey-card" href="#practice">
+      <span class="journey-n">3</span>
+      <h3>Practice the interview</h3>
+      <p>Role-play the questions you're most likely to get, as many times as you need.</p>
+      <span class="journey-go">Learn more →</span>
+    </a>
+    <a class="journey-card" href="#interviews">
+      <span class="journey-n">4</span>
+      <h3>Learn from the real ones</h3>
+      <p>Your coach observes your actual interviews and finds the patterns.</p>
+      <span class="journey-go">Learn more →</span>
+    </a>
+    <a class="journey-card" href="#negotiation">
+      <span class="journey-n">5</span>
+      <h3>Negotiate the offer</h3>
+      <p>Walk into the money conversation prepared, not hopeful.</p>
+      <span class="journey-go">Learn more →</span>
+    </a>
+  </div>
+</section>
+
+<section class="feature-section" id="features">
+  <div class="feature-row" id="resume">
+    <div class="feature-text">
+      <div class="feature-eyebrow">Step 1 · Résumé review</div>
+      <h3>Your résumé, read the way a recruiter reads it.</h3>
+      <p>Upload your résumé and your coach breaks it down line by line: which bullets prove impact, which ones list activity without outcomes, and which ones are costing you interviews. You get specific rewrites to make — not generic tips.</p>
+      <p>Then it keeps iterating with you until every line earns its place on the page.</p>
+    </div>
+    <div class="feature-visual" aria-hidden="true">
+      <div class="wc-content">
+        <div class="wc-meeting-title">Résumé review</div>
+        <div class="wc-meta">Coach read · 2 pages · 14 suggestions</div>
+        <div class="doc-line">
+          <div class="doc-quote">"Led cross-functional team on platform migration initiative"</div>
+          <div class="doc-note"><span class="doc-flag fix">Quantify</span><span>Activity, not impact. How big was the team? What did the migration save or unlock? Numbers make this bullet undeniable.</span></div>
+        </div>
+        <div class="doc-line">
+          <div class="doc-quote">"Responsible for various stakeholder communications"</div>
+          <div class="doc-note"><span class="doc-flag cut">Cut</span><span>"Responsible for" + "various" tells a recruiter nothing. Replace it with the hardest stakeholder problem you solved.</span></div>
+        </div>
+        <div class="doc-line">
+          <div class="doc-quote">"Grew activation rate from 31% to 47% in two quarters"</div>
+          <div class="doc-note"><span class="doc-flag keep">Strong</span><span>This is the bar. Specific, measurable, yours. Lead with bullets like this one.</span></div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div class="feature-row reverse" id="job-description">
+    <div class="feature-text">
+      <div class="feature-eyebrow">Step 2 · Job description analysis</div>
+      <h3>Know how the hiring manager will read you — before you apply.</h3>
+      <p>Paste in a job description and your coach analyzes it against your background: what the role really demands, where you're genuinely strong, and the gaps a hiring manager will quietly worry about.</p>
+      <p>No more guessing what's behind the bullet points. You walk in knowing exactly what to emphasize — and what objections to get ahead of.</p>
+    </div>
+    <div class="feature-visual" aria-hidden="true">
+      <div class="wc-content">
+        <div class="wc-meeting-title">Role fit: Senior PM, Growth</div>
+        <div class="wc-meta">Coach read · JD vs. your background</div>
+        <div class="fit-cols">
+          <div class="fit-col strengths">
+            <div class="fit-col-title">Your strengths</div>
+            <ul>
+              <li>Activation work maps directly to their funnel problem</li>
+              <li>You've shipped experiments at their scale</li>
+            </ul>
+          </div>
+          <div class="fit-col gaps">
+            <div class="fit-col-title">Likely concerns</div>
+            <ul>
+              <li>No marketplace experience — they'll probe this</li>
+              <li>Haven't managed PMs; the JD hints at a lead role</li>
+            </ul>
+          </div>
+        </div>
+        <div class="wc-rec">
+          <div class="wc-rec-icon">
+            <svg viewBox="0 0 24 24"><path d="M13 2L3 14h9l-1 8 10-12h-9l1-8z"/></svg>
+          </div>
+          <div>
+            <div class="wc-rec-title">Get ahead of the marketplace gap</div>
+            <div class="wc-rec-body">Your two-sided referral program is the closest analog. Prepare that story so the gap becomes a strength.</div>
+            <div class="wc-rec-actions">
+              <span class="wc-rec-link">Build the story with your coach →</span>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div class="feature-row" id="practice">
+    <div class="feature-text">
+      <div class="feature-eyebrow">Step 3 · Interview practice</div>
+      <h3>Walk in having already answered the hard questions.</h3>
+      <p>From the job description and your background, your coach generates the questions you're most likely to face — including the uncomfortable ones aimed straight at your gaps. Then you role-play the interview out loud, get feedback on every answer, and run it again.</p>
+      <p>Iterate until the answer that used to ramble is tight, specific, and yours. By the real interview, nothing surprises you.</p>
+    </div>
+    <div class="feature-visual" aria-hidden="true">
+      <div class="wc-content">
+        <div class="wc-meeting-title">Likely interview questions</div>
+        <div class="wc-meta">Generated from the JD + your background</div>
+        <ul class="q-list">
+          <li class="q-item">
+            <span class="q-tag">Behavioral</span>
+            <div class="q-text">"Tell me about a time you turned around a metric that was heading the wrong way."</div>
+          </li>
+          <li class="q-item">
+            <span class="q-tag probe">Gap probe</span>
+            <div class="q-text">"You haven't worked on a marketplace. How would you ramp up on two-sided dynamics?"</div>
+          </li>
+          <li class="q-item">
+            <span class="q-tag">Role-specific</span>
+            <div class="q-text">"Walk me through how you'd diagnose our activation drop in your first 30 days."</div>
+          </li>
+        </ul>
+        <div class="wc-rec">
+          <div class="wc-rec-icon">
+            <svg viewBox="0 0 24 24"><polygon points="5 3 19 12 5 21 5 3"/></svg>
+          </div>
+          <div>
+            <div class="wc-rec-title">Role-play this interview</div>
+            <div class="wc-rec-body">Attempt 3 — your marketplace answer is tighter. This time, land the referral-program story in under 90 seconds.</div>
+            <div class="wc-rec-actions">
+              <span class="wc-rec-link">Start the next rep →</span>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div class="feature-row reverse" id="interviews">
+    <div class="feature-text">
+      <div class="feature-eyebrow">Step 4 · Real interview review</div>
+      <h3>Most candidates never learn why they didn't get the offer. You will.</h3>
+      <p>Work Coach's recorder observes your actual interviews — no bot joins, nothing the interviewer can see. Afterward, your coach shows you what worked, what didn't, and the patterns repeating across every interview in your search.</p>
+      <p>Each weakness it finds becomes a practice session, so the mistake that cost you one interview never costs you another.</p>
+    </div>
+    <div class="feature-visual" aria-hidden="true">
+      <div class="wc-content">
+        <div class="wc-meeting-title">Across your interviews</div>
+        <div class="wc-meta">Coach read · 4 interviews · last 3 weeks</div>
+        <div class="wc-stats-row">
+          <div class="wc-stat-pill">
+            <div class="sp-label">Answers landed</div>
+            <div class="sp-value" style="color: var(--accent);">71<span class="unit">%</span></div>
+            <div class="sp-detail">up from 54%</div>
+          </div>
+          <div class="wc-stat-pill">
+            <div class="sp-label">Rambling answers</div>
+            <div class="sp-value" style="color: var(--amber);">3</div>
+            <div class="sp-detail">was 7 — improving</div>
+          </div>
+          <div class="wc-stat-pill">
+            <div class="sp-label">Questions you asked</div>
+            <div class="sp-value" style="color: var(--red);">1</div>
+            <div class="sp-detail">they notice this</div>
+          </div>
+        </div>
+        <div class="wc-rec">
+          <div class="wc-rec-icon">
+            <svg viewBox="0 0 24 24"><polyline points="23 6 13.5 15.5 8.5 10.5 1 18"/><polyline points="17 6 23 6 23 12"/></svg>
+          </div>
+          <div>
+            <div class="wc-rec-title">Pattern: you rush your opener</div>
+            <div class="wc-rec-body">In all 4 interviews, your "tell me about yourself" ran past 3 minutes and buried your best credential. Lead with the activation win.</div>
+            <div class="wc-rec-actions">
+              <span class="wc-rec-play">▶ 02:41</span>
+              <span class="wc-rec-play">▶ 01:58</span>
+              <span class="wc-rec-link">Practice a 60-second opener →</span>
+            </div>
+          </div>
+        </div>
+        <div class="wc-rec wc-rec-secondary">
+          <div class="wc-rec-icon">
+            <svg viewBox="0 0 24 24"><circle cx="12" cy="12" r="10"/><path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3"/><line x1="12" y1="17" x2="12.01" y2="17"/></svg>
+          </div>
+          <div>
+            <div class="wc-rec-title">Ask more questions</div>
+            <div class="wc-rec-body">Strong candidates interview the company back. Your coach has 5 questions ready for Thursday's final round.</div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div class="feature-row" id="negotiation">
+    <div class="feature-text">
+      <div class="feature-eyebrow">Step 5 · Offer negotiation</div>
+      <h3>The most expensive sentence in your career is "that sounds fine."</h3>
+      <p>When the offer lands, your coach helps you read it: how it stacks up, where the room is, and what to ask for. Then you rehearse the negotiation out loud — the counter, the silence after it, the pushback — until the real conversation feels like a rerun.</p>
+      <p>A few practiced minutes here can be worth more than every raise you've ever gotten.</p>
+    </div>
+    <div class="feature-visual" aria-hidden="true">
+      <div class="wc-content">
+        <div class="wc-meeting-title">Your offer: Senior PM, Growth</div>
+        <div class="wc-meta">Coach read · offer received yesterday</div>
+        <div class="offer-rows">
+          <div class="offer-row">
+            <span class="offer-label">Base salary</span>
+            <span class="offer-value">$168,000 <span style="color: var(--muted); font-weight: 400;">· below their band midpoint</span></span>
+          </div>
+          <div class="offer-row">
+            <span class="offer-label">Equity</span>
+            <span class="offer-value up">Room to ask · refreshers negotiable</span>
+          </div>
+          <div class="offer-row">
+            <span class="offer-label">Your leverage</span>
+            <span class="offer-value up">Strong — second onsite pending</span>
+          </div>
+        </div>
+        <div class="wc-rec">
+          <div class="wc-rec-icon">
+            <svg viewBox="0 0 24 24"><path d="M3 11l19-9-9 19-2-8-8-2z"/></svg>
+          </div>
+          <div>
+            <div class="wc-rec-title">They anchored low — counter with the number</div>
+            <div class="wc-rec-body">Ask for $185K base, citing the scope they added in the final round. Don't soften it with "I was hoping…" — state it and stop talking.</div>
+            <div class="wc-rec-actions">
+              <span class="wc-rec-link">Rehearse the call with your coach →</span>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<section class="pullquote-section">
+  <div class="pullquote-inner">
+    <h2>Interviewing is a skill. Almost nobody trains it.</h2>
+    <p>You'll interview maybe a few dozen times in your whole career — with years between each round. That's not enough reps to get good at something this high-stakes, and every mistake is invisible: companies don't tell you why you didn't get the offer.</p>
+    <p>Work Coach turns your search into a training loop. <strong>Every practice session, every real interview, every negotiation feeds back into what you work on next</strong> — so you get measurably better while the search is still happening, not after it's over.</p>
+  </div>
+</section>
+
+<section class="faq-section" id="faq">
+  <h2>Frequently asked questions</h2>
+  <div class="faq-grid">
+    <details>
+      <summary>Will the interviewer know Work Coach is there?</summary>
+      <p>No. Work Coach captures audio locally on your Mac — no bot joins the call, no notification appears, nothing is visible to anyone else in the meeting.</p>
+    </details>
+    <details>
+      <summary>What do I need to get started?</summary>
+      <p>Start your free trial and tell your coach about the search you're running. Upload your résumé, paste in the job descriptions you're targeting, and your coach takes it from there. Every plan begins with a 2-week free trial — no credit card required.</p>
+    </details>
+    <details>
+      <summary>How does the role-play practice work?</summary>
+      <p>Your coach plays the interviewer — out loud, in real time, using questions generated from the actual job description and your background. After each answer you get specific feedback, then you run it again. You can repeat a single question or a full interview as many times as you want.</p>
+    </details>
+    <details>
+      <summary>What if I'm just starting my search?</summary>
+      <p>That's the best time. Your coach starts with your résumé and a search plan, then layers in job description analysis and interview prep as applications turn into conversations. It also keeps the whole process organized so nothing slips.</p>
+    </details>
+    <details>
+      <summary>Can it really help with negotiation?</summary>
+      <p>Yes — and it's often where the coach pays for itself. Your coach helps you evaluate the offer, decide what to ask for, and rehearse the conversation out loud until you can deliver your counter without flinching.</p>
+    </details>
+    <details>
+      <summary>Is my data private?</summary>
+      <p>Completely. Your recordings, transcripts, résumé, and offer details are yours alone — never shared with employers or other users, and never used to train shared models. You can delete everything anytime.</p>
+    </details>
+    <details>
+      <summary>What does it cost?</summary>
+      <p>Plans start at $100/month for the AI coach, $250/month to add human review, and $500/month for live coaching sessions — compare that to a single session with a traditional interview coach. Every plan starts with a 2-week free trial. <a href="/#pricing" style="color: var(--accent);">See pricing</a>.</p>
+    </details>
+  </div>
+</section>
+
+<section class="cta-section">
+  <h2>Your next offer is a search away.</h2>
+  <p>Start with your résumé today. Your coach handles every step after that.</p>
+  <div class="cta-row">
+    <a href="https://my.work.coach" class="btn-primary btn-lg">Start Free Trial</a>
+    <a href="/" class="btn-outline btn-lg">Learn more about Work Coach</a>
+  </div>
+  <p class="fine-print">2-week free trial · No credit card · Your data stays yours</p>
+</section>
+</main>
+
+<footer>
+  <div class="footer-inner">
+    <p>Your data is never shared with your employer.</p>
+    <div class="footer-links">
+      <a href="privacy">Privacy</a>
+      <a href="support">Support</a>
+      <a href="#faq">FAQ</a>
+    </div>
+  </div>
+</footer>
+
+</body>
+</html>


### PR DESCRIPTION
New landing page at /job-search walking through the five coached stages
of a job search: resume review, job description analysis, interview
practice via role-play, real-interview review with cross-interview
patterns, and offer negotiation. Links to it from the homepage
'Land your dream job' use-case panel.

https://claude.ai/code/session_01ApGqc2hFpxcqJVAMSXwCGa