### PR TITLE
Simplify the use-cases section for faster scanning

### DIFF
--- a/index.html
+++ b/index.html
@@ -853,10 +853,10 @@ a:focus {
 }
 .usecases-layout {
   display: grid;
-  grid-template-columns: 234px minmax(0, 540px);
-  gap: 56px;
+  grid-template-columns: 234px minmax(0, 560px);
+  gap: 48px;
   justify-content: center;
-  align-items: start;
+  align-items: stretch;
 }
 .rail-label {
   font-size: 11px;
@@ -922,28 +922,28 @@ a:focus {
 }
 .usecase-panels {
   position: relative;
-  min-height: 360px;
+  min-height: 300px;
+  height: 100%;
 }
-.usecase-panel { display: none; }
+.usecase-panel {
+  display: none;
+  background: var(--card);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 32px 36px;
+}
 .usecase-panel.is-active {
-  display: block;
+  display: flex;
+  flex-direction: column;
+  min-height: 100%;
   animation: ucFade 0.35s ease-out;
 }
-.usecase-panel > div:first-child { margin-bottom: 22px; }
 @keyframes ucFade {
   from { opacity: 0; transform: translateY(6px); }
   to { opacity: 1; transform: translateY(0); }
 }
 @media (prefers-reduced-motion: reduce) {
   .usecase-panel.is-active { animation: none; }
-}
-.usecase-panel-eyebrow {
-  font-size: 12px;
-  letter-spacing: 0.16em;
-  text-transform: uppercase;
-  color: var(--accent);
-  font-weight: 700;
-  margin-bottom: 12px;
 }
 .usecase-panel h3 {
   font-family: 'Playfair Display', serif;
@@ -968,47 +968,22 @@ a:focus {
   transition: gap 0.2s, color 0.2s;
 }
 .usecase-cta:hover { color: var(--accent); }
+.usecase-panel .usecase-cta { margin-top: auto; padding-top: 24px; align-self: start; }
 
-/* Coaching checklist card inside use-case panels */
-.coach-card {
-  background: var(--card);
-  border: 1px solid var(--accent-dark);
-  border-radius: var(--radius);
-  box-shadow: 0 0 0 1px var(--accent-dark), 0 14px 40px rgba(0,0,0,0.09);
-  padding: 26px 28px;
+/* Coaching checklist inside use-case panels */
+.coach-list {
+  list-style: none;
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 12px 24px;
 }
-.coach-card-head {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 12px;
-  padding-bottom: 16px;
-  margin-bottom: 16px;
-  border-bottom: 1px solid var(--border);
-}
-.coach-card-title {
-  font-size: 12px;
-  letter-spacing: 0.1em;
-  text-transform: uppercase;
-  font-weight: 700;
-  color: var(--text);
-}
-.coach-card-tag {
-  font-size: 11px;
-  font-weight: 700;
-  color: var(--accent-2);
-  background: var(--green-soft);
-  padding: 4px 10px;
-  border-radius: 999px;
-  white-space: nowrap;
-}
-.coach-list { list-style: none; display: grid; gap: 13px; }
 .coach-item {
   display: grid;
   grid-template-columns: 22px 1fr;
   gap: 12px;
   align-items: start;
-  font-size: 15.5px;
+  font-size: 15px;
+  font-weight: 600;
   line-height: 1.45;
   color: var(--text);
 }
@@ -1383,7 +1358,8 @@ a:focus {
   .usecase-tab-title { font-size: 12.5px; }
   .usecase-icon { width: 28px; height: 28px; }
   .usecase-panels { min-height: 0; }
-  .usecase-panel > div:first-child { margin-bottom: 18px; }
+  .usecase-panel { padding: 24px 20px; }
+  .coach-list { grid-template-columns: 1fr; }
 }
 @media (max-width: 920px) and (min-width: 601px) {
   .usecases-layout { grid-template-columns: 1fr; gap: 32px; }
@@ -1477,110 +1453,65 @@ a:focus {
 
     <div class="usecase-panels">
       <div class="usecase-panel is-active" role="tabpanel" id="uc-panel-job" aria-labelledby="uc-tab-job" data-panel="job">
-        <div>
-          <div class="usecase-panel-eyebrow">For your job search</div>
-          <h3>Get your dream job.</h3>
-          <p>From the first application to the signed offer, your coach runs the whole search alongside you — and keeps you moving when momentum dips.</p>
-          <a href="job-search" class="usecase-cta">See how the job search works →</a>
-        </div>
-        <div class="coach-card">
-          <div class="coach-card-head">
-            <span class="coach-card-title">What your coach does</span>
-            <span class="coach-card-tag">AI&nbsp;+&nbsp;human</span>
-          </div>
-          <ul class="coach-list">
-              <li class="coach-item"><span class="coach-check" aria-hidden="true"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg></span><span>Organize and track your entire search process</span></li>
-              <li class="coach-item"><span class="coach-check" aria-hidden="true"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg></span><span>Review and sharpen your resume</span></li>
-              <li class="coach-item"><span class="coach-check" aria-hidden="true"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg></span><span>Prep you for every interview</span></li>
-              <li class="coach-item"><span class="coach-check" aria-hidden="true"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg></span><span>Analyze how you actually performed in your interviews</span></li>
-              <li class="coach-item"><span class="coach-check" aria-hidden="true"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg></span><span>Coach you through negotiating the offer</span></li>
-              <li class="coach-item"><span class="coach-check" aria-hidden="true"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg></span><span>Hold you accountable to your plan</span></li>
-          </ul>
-        </div>
+        <h3>Get your dream job.</h3>
+        <p>From the first application to the signed offer, your AI&nbsp;+&nbsp;human coach runs the whole search alongside you — and keeps you moving when momentum dips.</p>
+        <ul class="coach-list">
+            <li class="coach-item"><span class="coach-check" aria-hidden="true"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg></span><span>Track your whole search</span></li>
+            <li class="coach-item"><span class="coach-check" aria-hidden="true"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg></span><span>Sharpen your résumé</span></li>
+            <li class="coach-item"><span class="coach-check" aria-hidden="true"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg></span><span>Prep every interview</span></li>
+            <li class="coach-item"><span class="coach-check" aria-hidden="true"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg></span><span>Review your real interviews</span></li>
+            <li class="coach-item"><span class="coach-check" aria-hidden="true"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg></span><span>Negotiate the offer</span></li>
+            <li class="coach-item"><span class="coach-check" aria-hidden="true"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg></span><span>Keep you on plan</span></li>
+        </ul>
+        <a href="job-search" class="usecase-cta">See how the job search works →</a>
       </div>
 
       <div class="usecase-panel" role="tabpanel" id="uc-panel-promotion" aria-labelledby="uc-tab-promotion" data-panel="promotion" hidden>
-        <div>
-          <div class="usecase-panel-eyebrow">For getting promoted</div>
-          <h3>Build the case before the room decides.</h3>
-          <p>Promotions are earned in the months before review season. Your coach helps you close the gap to the next level and walk in with proof.</p>
-          <a href="#pricing" class="usecase-cta">See coaching plans →</a>
-        </div>
-        <div class="coach-card">
-          <div class="coach-card-head">
-            <span class="coach-card-title">What your coach does</span>
-            <span class="coach-card-tag">AI&nbsp;+&nbsp;human</span>
-          </div>
-          <ul class="coach-list">
-              <li class="coach-item"><span class="coach-check" aria-hidden="true"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg></span><span>Analyze how you're doing relative to your level</span></li>
-              <li class="coach-item"><span class="coach-check" aria-hidden="true"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg></span><span>Review your 1:1s with your manager</span></li>
-              <li class="coach-item"><span class="coach-check" aria-hidden="true"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg></span><span>Help you build a concrete promotion plan</span></li>
-              <li class="coach-item"><span class="coach-check" aria-hidden="true"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg></span><span>Practice the conversation with your manager</span></li>
-              <li class="coach-item"><span class="coach-check" aria-hidden="true"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg></span><span>Keep you accountable to the plan</span></li>
-          </ul>
-        </div>
+        <h3>Build the case before the room decides.</h3>
+        <p>Promotions are earned in the months before review season. Your AI&nbsp;+&nbsp;human coach helps you close the gap to the next level and walk in with proof.</p>
+        <ul class="coach-list">
+            <li class="coach-item"><span class="coach-check" aria-hidden="true"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg></span><span>Benchmark you against your level</span></li>
+            <li class="coach-item"><span class="coach-check" aria-hidden="true"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg></span><span>Review your manager 1:1s</span></li>
+            <li class="coach-item"><span class="coach-check" aria-hidden="true"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg></span><span>Build your promotion plan</span></li>
+            <li class="coach-item"><span class="coach-check" aria-hidden="true"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg></span><span>Practice the conversation</span></li>
+            <li class="coach-item"><span class="coach-check" aria-hidden="true"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg></span><span>Keep you on plan</span></li>
+        </ul>
+        <a href="#pricing" class="usecase-cta">See coaching plans →</a>
       </div>
 
       <div class="usecase-panel" role="tabpanel" id="uc-panel-team" aria-labelledby="uc-tab-team" data-panel="team" hidden>
-        <div>
-          <div class="usecase-panel-eyebrow">For managers</div>
-          <h3>Lead each person the way they need.</h3>
-          <p>Great managers adapt to who's in front of them. Your coach helps you understand your team and bring out their best work.</p>
-          <a href="#pricing" class="usecase-cta">See coaching plans →</a>
-        </div>
-        <div class="coach-card">
-          <div class="coach-card-head">
-            <span class="coach-card-title">What your coach does</span>
-            <span class="coach-card-tag">AI&nbsp;+&nbsp;human</span>
-          </div>
-          <ul class="coach-list">
-              <li class="coach-item"><span class="coach-check" aria-hidden="true"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg></span><span>Analyze your team's personalities and working styles</span></li>
-              <li class="coach-item"><span class="coach-check" aria-hidden="true"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg></span><span>Show how well you're supporting and empowering them</span></li>
-              <li class="coach-item"><span class="coach-check" aria-hidden="true"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg></span><span>Surface where you can push them to be their best</span></li>
-          </ul>
-        </div>
+        <h3>Lead each person the way they need.</h3>
+        <p>Great managers adapt to who's in front of them. Your AI&nbsp;+&nbsp;human coach helps you understand your team and bring out their best work.</p>
+        <ul class="coach-list">
+            <li class="coach-item"><span class="coach-check" aria-hidden="true"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg></span><span>Decode personalities and styles</span></li>
+            <li class="coach-item"><span class="coach-check" aria-hidden="true"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg></span><span>Measure how you support them</span></li>
+            <li class="coach-item"><span class="coach-check" aria-hidden="true"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg></span><span>Spot where to push them</span></li>
+        </ul>
+        <a href="#pricing" class="usecase-cta">See coaching plans →</a>
       </div>
 
       <div class="usecase-panel" role="tabpanel" id="uc-panel-advocacy" aria-labelledby="uc-tab-advocacy" data-panel="advocacy" hidden>
-        <div>
-          <div class="usecase-panel-eyebrow">For self-advocacy</div>
-          <h3>Make sure your work gets seen.</h3>
-          <p>Doing great work isn't enough if no one notices. Your coach helps you speak up for yourself in the moments that count.</p>
-          <a href="#pricing" class="usecase-cta">See coaching plans →</a>
-        </div>
-        <div class="coach-card">
-          <div class="coach-card-head">
-            <span class="coach-card-title">What your coach does</span>
-            <span class="coach-card-tag">AI&nbsp;+&nbsp;human</span>
-          </div>
-          <ul class="coach-list">
-              <li class="coach-item"><span class="coach-check" aria-hidden="true"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg></span><span>Get clear on what you actually want</span></li>
-              <li class="coach-item"><span class="coach-check" aria-hidden="true"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg></span><span>Evaluate how you're doing in meetings</span></li>
-              <li class="coach-item"><span class="coach-check" aria-hidden="true"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg></span><span>Give you suggestions to communicate with impact</span></li>
-              <li class="coach-item"><span class="coach-check" aria-hidden="true"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg></span><span>Factor in personalities so you advocate the right way for the room</span></li>
-          </ul>
-        </div>
+        <h3>Make sure your work gets seen.</h3>
+        <p>Doing great work isn't enough if no one notices. Your AI&nbsp;+&nbsp;human coach helps you speak up for yourself in the moments that count.</p>
+        <ul class="coach-list">
+            <li class="coach-item"><span class="coach-check" aria-hidden="true"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg></span><span>Clarify what you want</span></li>
+            <li class="coach-item"><span class="coach-check" aria-hidden="true"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg></span><span>Evaluate your meetings</span></li>
+            <li class="coach-item"><span class="coach-check" aria-hidden="true"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg></span><span>Sharpen your communication</span></li>
+            <li class="coach-item"><span class="coach-check" aria-hidden="true"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg></span><span>Read the room right</span></li>
+        </ul>
+        <a href="#pricing" class="usecase-cta">See coaching plans →</a>
       </div>
 
       <div class="usecase-panel" role="tabpanel" id="uc-panel-confidence" aria-labelledby="uc-tab-confidence" data-panel="confidence" hidden>
-        <div>
-          <div class="usecase-panel-eyebrow">For confidence</div>
-          <h3>Show up like you belong in the room.</h3>
-          <p>Confidence is a skill you can build. Your coach gives you targets, feedback, and reps until showing up strong feels natural.</p>
-          <a href="#pricing" class="usecase-cta">See coaching plans →</a>
-        </div>
-        <div class="coach-card">
-          <div class="coach-card-head">
-            <span class="coach-card-title">What your coach does</span>
-            <span class="coach-card-tag">AI&nbsp;+&nbsp;human</span>
-          </div>
-          <ul class="coach-list">
-              <li class="coach-item"><span class="coach-check" aria-hidden="true"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg></span><span>Understand your goals and set accountability targets</span></li>
-              <li class="coach-item"><span class="coach-check" aria-hidden="true"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg></span><span>Analyze how you show up across your online meetings</span></li>
-              <li class="coach-item"><span class="coach-check" aria-hidden="true"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg></span><span>Help you frame your arguments more clearly</span></li>
-              <li class="coach-item"><span class="coach-check" aria-hidden="true"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg></span><span>Coach you to speak more confidently and break down problems</span></li>
-          </ul>
-        </div>
+        <h3>Show up like you belong in the room.</h3>
+        <p>Confidence is a skill you can build. Your AI&nbsp;+&nbsp;human coach gives you targets, feedback, and reps until showing up strong feels natural.</p>
+        <ul class="coach-list">
+            <li class="coach-item"><span class="coach-check" aria-hidden="true"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg></span><span>Set accountability targets</span></li>
+            <li class="coach-item"><span class="coach-check" aria-hidden="true"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg></span><span>Analyze how you show up</span></li>
+            <li class="coach-item"><span class="coach-check" aria-hidden="true"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg></span><span>Frame arguments clearly</span></li>
+            <li class="coach-item"><span class="coach-check" aria-hidden="true"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg></span><span>Build speaking confidence</span></li>
+        </ul>
+        <a href="#pricing" class="usecase-cta">See coaching plans →</a>
       </div>
     </div>
     </div>


### PR DESCRIPTION
- Drop the redundant panel eyebrows and the "What your coach does" card chrome (header, AI + human badge); fold "AI + human" into each panel paragraph.
- Compress checklist items to short verb phrases in a two-column grid.
- Wrap each panel in a single card matching the tab material, stretch it to the tab column height, and pin the CTA to the bottom edge.