### PR TITLE
Remove AI-copywriting tells from index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,7 +13,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
 <meta name="description" content="Feedback to help you rock interviews, get a promotion, speak more confidently, and advocate for yourself. Work Coach observes the meetings you already have and shows you what to work on next.">
 <meta name="color-scheme" content="light">
-<title>Work Coach — Feedback to help you grow at work.</title>
+<title>Work Coach: Feedback to help you grow at work.</title>
 <link rel="canonical" href="https://work.coach/">
 <link rel="icon" href="img/favicon.ico">
 <link rel="icon" type="image/png" sizes="32x32" href="img/favicon-32.png">
@@ -23,7 +23,7 @@
 <meta property="og:type" content="website">
 <meta property="og:url" content="https://work.coach/">
 <meta property="og:site_name" content="Work Coach">
-<meta property="og:title" content="Work Coach — An AI coach that finds out what's holding you back.">
+<meta property="og:title" content="Work Coach: An AI coach that finds out what's holding you back.">
 <meta property="og:description" content="The feedback nobody tells you. Work Coach observes your meetings and helps you improve over time.">
 <meta property="og:image" content="https://work.coach/img/og-image.png">
 <meta property="og:image:width" content="1200">
@@ -31,7 +31,7 @@
 <meta property="og:image:alt" content="Work Coach meeting analysis screen">
 
 <meta name="twitter:card" content="summary_large_image">
-<meta name="twitter:title" content="Work Coach — An AI coach that finds out what's holding you back.">
+<meta name="twitter:title" content="Work Coach: An AI coach that finds out what's holding you back.">
 <meta name="twitter:description" content="The feedback nobody tells you. Work Coach observes your meetings and helps you improve over time.">
 <meta name="twitter:image" content="https://work.coach/img/og-image.png">
 
@@ -1411,7 +1411,7 @@ a:focus {
   <div class="usecases-inner">
     <div class="usecases-head">
       <h2>You're already paying for the coach you don't have</h2>
-      <p class="usecases-sub">Executives know how valuable coaches are: they're paying $5,000 a month. Work Coach does more for a fraction of the cost — with the option to add a real human coach.</p>
+      <p class="usecases-sub">Executives know how valuable coaches are: they're paying $5,000 a month. Work Coach does more for a fraction of the cost, with the option to add a real human coach.</p>
     </div>
 
     <div class="usecases-layout">
@@ -1454,7 +1454,7 @@ a:focus {
     <div class="usecase-panels">
       <div class="usecase-panel is-active" role="tabpanel" id="uc-panel-job" aria-labelledby="uc-tab-job" data-panel="job">
         <h3>Get your dream job.</h3>
-        <p>From the first application to the signed offer, your AI&nbsp;+&nbsp;human coach runs the whole search alongside you — and keeps you moving when momentum dips.</p>
+        <p>From the first application to the signed offer, your AI&nbsp;+&nbsp;human coach runs the whole search alongside you and keeps you moving when momentum dips.</p>
         <ul class="coach-list">
             <li class="coach-item"><span class="coach-check" aria-hidden="true"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg></span><span>Track your whole search</span></li>
             <li class="coach-item"><span class="coach-check" aria-hidden="true"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg></span><span>Sharpen your résumé</span></li>
@@ -1521,12 +1521,12 @@ a:focus {
 <section class="pullquote-section">
   <div class="pullquote-inner">
     <h2>Coaching shouldn't cost $5,000 a month</h2>
-    <p>The best leaders have always had someone in their corner — someone who challenges their thinking, watches their blind spots, and helps them navigate complexity.</p>
-    <p>That used to require a <strong>$5,000-a-month engagement</strong> and a C-suite title. Work Coach brings the same model to everyone: real feedback, real patterns, real coaching — starting with your next meeting or your next interview.</p>
+    <p>The best leaders have always had someone in their corner who challenges their thinking, watches their blind spots, and helps them navigate complexity.</p>
+    <p>That used to require a <strong>$5,000-a-month engagement</strong> and a C-suite title. Work Coach brings the same model to everyone: real feedback, real patterns, real coaching, starting with your next meeting or your next interview.</p>
     <div class="pullquote-traits">
-      <div class="pullquote-trait"><span class="trait-accent">Voice-native</span> — walk and think</div>
-      <div class="pullquote-trait"><span class="trait-accent">Context-aware</span> — no catching up</div>
-      <div class="pullquote-trait"><span class="trait-accent">Private</span> — completely honest</div>
+      <div class="pullquote-trait"><span class="trait-accent">Voice-native</span>: walk and think</div>
+      <div class="pullquote-trait"><span class="trait-accent">Context-aware</span>: no catching up</div>
+      <div class="pullquote-trait"><span class="trait-accent">Private</span>: completely honest</div>
     </div>
   </div>
 </section>
@@ -1536,8 +1536,8 @@ a:focus {
   <div class="compat-grid">
     <div class="compat-text">
       <div class="section-label">A coach that has the full context of your work</div>
-      <h2>Focus on your next step, not what happened.</h2>
-      <p>A human coach can't sit in your meetings, and doesn't have time to read your transcripts — so every session starts with you explaining what happened. Work Coach already knows. It sees your meetings through its own recorder, or reads the transcripts you already keep in Granola — so you skip the recap and go straight to your reaction, and what you want to do about it.</p>
+      <h2>Focus on your next step.</h2>
+      <p>A human coach can't sit in your meetings, and doesn't have time to read your transcripts, so every session starts with you explaining what happened. Work Coach already knows. It sees your meetings through its own recorder, or reads the transcripts you already keep in Granola, so you skip the recap and go straight to your reaction, and what you want to do about it.</p>
     </div>
     <div class="compat-visual">
       <div class="context-card" aria-hidden="true">
@@ -1552,7 +1552,7 @@ a:focus {
             </span>
             <div>
               <div class="ctx-source-name">Built-in recorder</div>
-              <div class="ctx-source-desc">Captures your meetings locally — no bot, nothing leaves your Mac.</div>
+              <div class="ctx-source-desc">Captures your meetings locally. No bot, and nothing leaves your Mac.</div>
             </div>
           </div>
           <div class="ctx-source">
@@ -1572,7 +1572,7 @@ a:focus {
           </div>
           <div class="ctx-line us">
             <span class="ctx-who">Work Coach</span>
-            <span class="ctx-what">Already knows — straight to what you'll do</span>
+            <span class="ctx-what">Already knows. Straight to what you'll do</span>
           </div>
         </div>
       </div>
@@ -1584,14 +1584,14 @@ a:focus {
   <div class="how-head">
     <div class="section-label">How it works</div>
     <h2>How your coach actually gets to know you.</h2>
-    <p>A great coach does the homework before you even meet — and keeps working as it sees you in action. Here's how Work Coach gets to know you and helps you grow.</p>
+    <p>A great coach does the homework before you even meet, then keeps working as it sees you in action. Here's how Work Coach gets to know you and helps you grow.</p>
   </div>
   <div class="how-rail">
     <div class="how-step">
       <div class="how-step-index">01</div>
       <div>
         <h3>It does its homework</h3>
-        <p>Before your first session, your coach researches you — your background and where you're trying to go — and forms a real point of view. It shows up to that first meeting with a perspective, not a blank slate.</p>
+        <p>Before your first session, your coach researches your background and where you're trying to go. It shows up to that first meeting having already formed a real point of view.</p>
       </div>
       <div class="how-step-tag">Before you meet</div>
     </div>
@@ -1599,7 +1599,7 @@ a:focus {
       <div class="how-step-index">02</div>
       <div>
         <h3>You set it straight</h3>
-        <p>You confirm or correct what it got right — your real goals and what actually motivates you — so everything that follows is built around what you care about.</p>
+        <p>You confirm or correct its read on your real goals and what actually motivates you, so everything that follows is built around what you care about.</p>
       </div>
       <div class="how-step-tag">Your goals, your way</div>
     </div>
@@ -1607,7 +1607,7 @@ a:focus {
       <div class="how-step-index">03</div>
       <div>
         <h3>It goes to work</h3>
-        <p>Your coach helps you navigate the goal — landing a job and running the whole process, managing your team, or gaining influence — by observing how you actually show up at work.</p>
+        <p>By observing how you actually show up at work, your coach helps you navigate the goal: landing a job and running the whole process, managing your team, or gaining influence.</p>
       </div>
       <div class="how-step-tag">No bot joins</div>
     </div>
@@ -1623,7 +1623,7 @@ a:focus {
       <div class="how-step-index">05</div>
       <div>
         <h3>It keeps you on track</h3>
-        <p>Your coach holds you accountable to the plan — checking in, keeping you honest about your progress, and helping you actually realize the goal you set out to reach.</p>
+        <p>Your coach holds you accountable to the plan: checking in, keeping you honest about your progress, and helping you actually realize the goal you set out to reach.</p>
       </div>
       <div class="how-step-tag">Accountability</div>
     </div>
@@ -1634,12 +1634,12 @@ a:focus {
   <div class="feature-head">
     <div class="section-label">What your coach sees</div>
     <h2>Every goal, powered by what happens in your meetings.</h2>
-    <p>Generic advice is easy to ignore. Because your coach learns from your real conversations, every recommendation is tied to a goal you're working on — and a moment you can replay.</p>
+    <p>Generic advice is easy to ignore. Because your coach learns from your real conversations, every recommendation is tied to a goal you're working on and a moment you can replay.</p>
   </div>
   <div class="feature-row">
     <div class="feature-text">
       <div class="feature-eyebrow">Get a job</div>
-      <h3>Land the right role — the whole search, handled.</h3>
+      <h3>Land the right role. The whole search, handled.</h3>
       <p>From a sharper résumé to a strong first 90 days, your coach runs the entire process with you: the plan, the applications, interview prep, the negotiation, and a fast start. Nothing slips, and you always know the next move.</p>
       <a href="job-search" class="usecase-cta">See how the job search works →</a>
     </div>
@@ -1722,7 +1722,7 @@ a:focus {
     <div class="feature-text">
       <div class="feature-eyebrow">Be more confident at work</div>
       <h3>Confidence is leverage. Build it on purpose.</h3>
-      <p>Whether people defer to you or talk over you is decided in seconds — by the hedges, the trailing sentences, the strong opinion you softened into a question. Your coach finds exactly where you give away authority and trains it out of you, week over week, until being the most credible voice in the room is simply how you show up.</p>
+      <p>Whether people defer to you or talk over you is decided in seconds: by the hedges, the trailing sentences, the strong opinion you softened into a question. Your coach finds exactly where you give away authority and trains it out of you, week over week, until being the most credible voice in the room is simply how you show up.</p>
     </div>
     <div class="feature-visual" aria-hidden="true">
       <div class="wc-content">
@@ -1751,7 +1751,7 @@ a:focus {
           </div>
           <div>
             <div class="wc-rec-title">Stop softening your strongest ideas</div>
-            <div class="wc-rec-body">You hedge your best recommendations with "this might be off, but…" — say them plainly.</div>
+            <div class="wc-rec-body">You hedge your best recommendations with "this might be off, but…" Say them plainly.</div>
             <div class="wc-rec-actions">
               <span class="wc-rec-play">▶ 09:14</span>
               <span class="wc-rec-link">Practice the direct version →</span>
@@ -1765,7 +1765,7 @@ a:focus {
     <div class="feature-text">
       <div class="feature-eyebrow">Advocate for yourself</div>
       <h3>Make sure the room remembers it was yours.</h3>
-      <p>Great work goes unrewarded when you let someone else reframe it, restate it, or run with it. Your coach catches the moments you undersold a win or let your point get buried, then helps you rehearse the version where you take the credit and hold the floor — so your impact is impossible to overlook when it counts.</p>
+      <p>Great work goes unrewarded when you let someone else reframe it, restate it, or run with it. Your coach catches the moments you undersold a win or let your point get buried, then helps you rehearse the version where you take the credit and hold the floor, so your impact is impossible to overlook when it counts.</p>
     </div>
     <div class="feature-visual" aria-hidden="true">
       <div class="wc-content">
@@ -1794,7 +1794,7 @@ a:focus {
           </div>
           <div>
             <div class="wc-rec-title">Your idea, someone else's name</div>
-            <div class="wc-rec-body">At 18:42 you proposed the staffing fix. At 31:10 it came back as "Jake's plan" — and you didn't step in. Next time, claim it: "Glad this landed — it's the approach I raised earlier."</div>
+            <div class="wc-rec-body">At 18:42 you proposed the staffing fix. At 31:10 it came back as "Jake's plan" and you didn't step in. Next time, claim it: "Glad this landed. It's the approach I raised earlier."</div>
             <div class="wc-rec-actions">
               <span class="wc-rec-play">▶ 18:42</span>
               <span class="wc-rec-play">▶ 31:10</span>
@@ -1809,7 +1809,7 @@ a:focus {
     <div class="feature-text">
       <div class="feature-eyebrow">Get the most from your team</div>
       <h3>Become the manager people do their best work for.</h3>
-      <p>Your team is always telling you what they need — in what gets raised, what gets dropped, and what goes unsaid. Your coach connects those signals across every 1:1 and team meeting so you can lead each person deliberately, catch the small problems before they grow, and build a team people don't want to leave.</p>
+      <p>Your team is always telling you what they need: in what gets raised, what gets dropped, and what goes unsaid. Your coach connects those signals across every 1:1 and team meeting so you can lead each person deliberately, catch the small problems before they grow, and build a team people don't want to leave.</p>
     </div>
     <div class="feature-visual" aria-hidden="true">
       <div class="wc-content">
@@ -1819,12 +1819,12 @@ a:focus {
           <div class="wc-stat-pill">
             <div class="sp-label">Flight risk</div>
             <div class="sp-value" style="color: var(--red);">1</div>
-            <div class="sp-detail">Jake — disengaging</div>
+            <div class="sp-detail">Jake: disengaging</div>
           </div>
           <div class="wc-stat-pill">
             <div class="sp-label">Ready for more</div>
             <div class="sp-value" style="color: var(--accent);">1</div>
-            <div class="sp-detail">Priya — give scope</div>
+            <div class="sp-detail">Priya: give scope</div>
           </div>
           <div class="wc-stat-pill">
             <div class="sp-label">Unowned actions</div>
@@ -1838,7 +1838,7 @@ a:focus {
           </div>
           <div>
             <div class="wc-rec-title">Jake is telling you he's stuck</div>
-            <div class="wc-rec-body">Resource concerns in 3 of his last 5 1:1s, each conversation shorter than the one before. That's what disengagement sounds like before someone leaves — address it before the next planning cycle.</div>
+            <div class="wc-rec-body">Resource concerns in 3 of his last 5 1:1s, each conversation shorter than the one before. That's what disengagement sounds like before someone leaves. Address it before the next planning cycle.</div>
             <div class="wc-rec-actions">
               <span class="wc-rec-play">▶ 22:17</span>
               <span class="wc-rec-link">Prep the conversation →</span>
@@ -1861,7 +1861,7 @@ a:focus {
     <div class="feature-text">
       <div class="feature-eyebrow">Get a promotion</div>
       <h3>No one is coming to promote you. Captain it yourself.</h3>
-      <p>The people who get promoted drive the process — they don't wait to be noticed. Your coach helps you own it: build a plan, score yourself honestly against the rubric, and name your gaps and exactly what you're doing about them. Then it preps you to ask your manager for guidance on that plan, and to relentlessly communicate every win along the way — so your manager has everything they need to champion your case for you.</p>
+      <p>The people who get promoted drive the process instead of waiting to be noticed. Your coach helps you own it: build a plan, score yourself honestly against the rubric, and name your gaps and exactly what you're doing about them. Then it preps you to ask your manager for guidance on that plan, and to relentlessly communicate every win along the way, so your manager has everything they need to champion your case for you.</p>
     </div>
     <div class="feature-visual" aria-hidden="true">
       <div class="wc-content">
@@ -1901,8 +1901,8 @@ a:focus {
             <svg viewBox="0 0 24 24"><polyline points="23 6 13.5 15.5 8.5 10.5 1 18"/><polyline points="17 6 23 6 23 12"/></svg>
           </div>
           <div>
-            <div class="wc-rec-title">You're closing the gap — make it undeniable</div>
-            <div class="wc-rec-body">Your last three staff meetings showed clear senior-level judgment. Capture those moments now so your case writes itself at review — instead of scrambling to remember wins six weeks from now.</div>
+            <div class="wc-rec-title">You're closing the gap. Make it undeniable</div>
+            <div class="wc-rec-body">Your last three staff meetings showed clear senior-level judgment. Capture those moments now so your case writes itself at review instead of scrambling to remember wins six weeks from now.</div>
             <div class="wc-rec-actions">
               <span class="wc-rec-play">▶ Apr 18 · 41:22</span>
               <span class="wc-rec-link">Add to promotion packet →</span>
@@ -1928,8 +1928,8 @@ a:focus {
       <div class="price-amount"><span class="num">$100</span><span class="per">/ month</span></div>
       <ul class="price-features">
         <li class="price-feature"><span class="coach-check" aria-hidden="true"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg></span><span>Coaching that observes and coaches you based on your real meetings</span></li>
-        <li class="price-feature"><span class="coach-check" aria-hidden="true"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg></span><span>Coaching frameworks tuned to your industry, seniority, and function — not generic AI advice</span></li>
-        <li class="price-feature"><span class="coach-check" aria-hidden="true"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg></span><span>Adapts to the meeting — interviews, 1:1s, team meetings, presentations, sales calls</span></li>
+        <li class="price-feature"><span class="coach-check" aria-hidden="true"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg></span><span>Coaching frameworks tuned to your industry, seniority, and function</span></li>
+        <li class="price-feature"><span class="coach-check" aria-hidden="true"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg></span><span>Adapts to the meeting: interviews, 1:1s, team meetings, presentations, sales calls</span></li>
         <li class="price-feature"><span class="coach-check" aria-hidden="true"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg></span><span>Unlimited voice coaching, 24/7</span></li>
         <li class="price-feature"><span class="coach-check" aria-hidden="true"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg></span><span>Check-ins that keep you on track toward your goal</span></li>
       </ul>
@@ -1940,12 +1940,12 @@ a:focus {
       <span class="price-badge">Most popular</span>
       <div class="price-eyebrow">AI + Human Review</div>
       <div class="price-name">Coach + Review</div>
-      <p class="price-tagline">A real coach's eyes on your actual progress — for less than one traditional session.</p>
+      <p class="price-tagline">A real coach's eyes on your actual progress, for less than one traditional session.</p>
       <div class="price-amount"><span class="num">$250</span><span class="per">/ month</span></div>
       <ul class="price-features">
         <li class="price-feature"><span class="coach-check" aria-hidden="true"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg></span><span>Async human review of your coaching feedback</span></li>
         <li class="price-feature"><span class="coach-check" aria-hidden="true"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg></span><span>Monthly written report: what's improving, what's stalled, what to work on next</span></li>
-        <li class="price-feature"><span class="coach-check" aria-hidden="true"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg></span><span>Catches what AI can't — tone, politics, blind spots</span></li>
+        <li class="price-feature"><span class="coach-check" aria-hidden="true"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg></span><span>Catches what AI can't: tone, politics, blind spots</span></li>
         <li class="price-feature"><span class="coach-check" aria-hidden="true"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg></span><span>Everything in Coach</span></li>
       </ul>
       <a href="https://my.work.coach" class="btn-primary btn-lg">Start Free Trial</a>
@@ -1957,15 +1957,15 @@ a:focus {
       <p class="price-tagline">AI, human review, plus a coach in the room with you.</p>
       <div class="price-amount"><span class="num">$500</span><span class="per">/ month</span></div>
       <ul class="price-features">
-        <li class="price-feature"><span class="coach-check" aria-hidden="true"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg></span><span>A live monthly session with a coach who has reviewed your feedback — no catching them up</span></li>
-        <li class="price-feature"><span class="coach-check" aria-hidden="true"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg></span><span>Role-play your highest-stakes moments live — the promotion ask, the negotiation, the hard feedback</span></li>
-        <li class="price-feature"><span class="coach-check" aria-hidden="true"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg></span><span>Priority access when something urgent hits — a surprise offer, a conflict, a reorg</span></li>
+        <li class="price-feature"><span class="coach-check" aria-hidden="true"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg></span><span>A live monthly session with a coach who shows up already briefed on your feedback</span></li>
+        <li class="price-feature"><span class="coach-check" aria-hidden="true"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg></span><span>Role-play your highest-stakes moments live: the promotion ask, the negotiation, the hard feedback</span></li>
+        <li class="price-feature"><span class="coach-check" aria-hidden="true"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg></span><span>Priority access when something urgent hits: a surprise offer, a conflict, a reorg</span></li>
         <li class="price-feature"><span class="coach-check" aria-hidden="true"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg></span><span>Everything in Coach + Review</span></li>
       </ul>
       <a href="https://my.work.coach" class="btn-outline btn-lg">Start Free Trial</a>
     </div>
   </div>
-  <p class="pricing-note">Every plan is built on an AI coach that learns from your real meetings — and a traditional executive coach runs $5,000 a month. Higher tiers layer in a real, live human coach.</p>
+  <p class="pricing-note">Every plan is built on an AI coach that learns from your real meetings. For comparison, a traditional executive coach runs $5,000 a month. Higher tiers layer in a real, live human coach.</p>
 </section>
 
 <section class="faq-section" id="faq">
@@ -1973,11 +1973,11 @@ a:focus {
   <div class="faq-grid">
     <details>
       <summary>What do I need to get started?</summary>
-      <p>Join the waitlist and tell us your goal. Once you're in, you download the Mac app and your coach starts learning from your meetings. Every plan begins with a 2-week free trial — no credit card required.</p>
+      <p>Join the waitlist and tell us your goal. Once you're in, you download the Mac app and your coach starts learning from your meetings. Every plan begins with a 2-week free trial with no credit card required.</p>
     </details>
     <details>
       <summary>Is there a real human coach?</summary>
-      <p>Yes — that's your choice. The base plan ($100/mo) is your always-on AI coach. Add human review of your progress ($250/mo), or a live monthly session with a real work coach ($500/mo). You can change tiers anytime.</p>
+      <p>Yes, that's your choice. The base plan ($100/mo) is your always-on AI coach. Add human review of your progress ($250/mo), or a live monthly session with a real work coach ($500/mo). You can change tiers anytime.</p>
     </details>
     <details>
       <summary>Does a bot join my calls?</summary>
@@ -1989,7 +1989,7 @@ a:focus {
     </details>
     <details>
       <summary>Will my employer care?</summary>
-      <p>Work Coach doesn't capture proprietary information — it analyzes you, not your company's secrets. Your recordings and transcripts are private and never shared.</p>
+      <p>Work Coach analyzes how you communicate and ignores your company's proprietary information. Your recordings and transcripts are private and never shared.</p>
     </details>
     <details>
       <summary>Do you share data with anyone?</summary>
@@ -1997,11 +1997,11 @@ a:focus {
     </details>
     <details>
       <summary>Who is this for?</summary>
-      <p>Anyone who wants to be better in professional conversations — whether you're leading a team, collaborating with peers, or interviewing for your next role.</p>
+      <p>Anyone who wants to be better in professional conversations, whether you're leading a team, collaborating with peers, or interviewing for your next role.</p>
     </details>
     <details>
       <summary>What does it cost?</summary>
-      <p>Plans start at $100/month for the AI coach, $250/month to add human review, and $500/month for live coaching sessions. Every plan starts with a 2-week free trial — no credit card required.</p>
+      <p>Plans start at $100/month for the AI coach, $250/month to add human review, and $500/month for live coaching sessions. Every plan starts with a 2-week free trial with no credit card required.</p>
     </details>
   </div>
 </section>


### PR DESCRIPTION
## Summary
Scrubs the telltale patterns of AI-generated copy from index.html:

- **Em dashes removed from all visible copy** (~35 instances across the hero, use-case panels, how-it-works steps, feature paragraphs, pricing cards, and FAQ) — each rewritten case by case with commas, colons before lists, or sentence breaks so the copy still reads naturally.
- **"X, not Y" contrast constructions restated directly:**
  - "Focus on your next step, not what happened." → "Focus on your next step."
  - "with a perspective, not a blank slate" → "having already formed a real point of view"
  - "it analyzes you, not your company's secrets" → "analyzes how you communicate and ignores your company's proprietary information"
  - "— not generic AI advice" (pricing bullet) → dropped
  - "they don't wait to be noticed" → "instead of waiting to be noticed"
- **Page titles** switch from "Work Coach — …" to "Work Coach: …" in `<title>` and OG/Twitter meta.

The only remaining em dash in the file is inside a CSS code comment, which is never rendered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)