### PR TITLE
Move Google Ads conversion to Start Free Trial CTAs

### DIFF
--- a/about.html
+++ b/about.html
@@ -9,6 +9,46 @@
   gtag('js', new Date());
   gtag('config', 'AW-1021884186');
 </script>
+<script>
+  // Google Ads conversion for "Start Free Trial" CTAs (links to my.work.coach).
+  // Fires the conversion, then follows the link once it registers (event_callback)
+  // so the ping isn't lost to navigation. Falls back if gtag is blocked/slow.
+  (function() {
+    function reportTrialConversion(url) {
+      var navigated = false;
+      var go = function () {
+        if (navigated) return;
+        navigated = true;
+        if (url) window.location = url;
+      };
+      try {
+        if (typeof gtag === 'function') {
+          gtag('event', 'conversion', {
+            'send_to': 'AW-1021884186/UYaXCOa_mbUcEJruoucD',
+            'event_callback': go
+          });
+          setTimeout(go, 1000); // fallback if the callback never fires
+        } else {
+          go();
+        }
+      } catch (e) {
+        go();
+      }
+    }
+
+    document.addEventListener('click', function(e) {
+      var link = e.target.closest ? e.target.closest('a[href^="https://my.work.coach"]') : null;
+      if (!link) return;
+      // Let new-tab / modified clicks open natively; still fire the conversion ping.
+      if (e.defaultPrevented || e.button !== 0 || e.metaKey || e.ctrlKey || e.shiftKey || e.altKey || link.target === '_blank') {
+        reportTrialConversion();
+        return;
+      }
+      e.preventDefault();
+      reportTrialConversion(link.href);
+    });
+  })();
+</script>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <meta name="description" content="Dan Wolchonok has 20 years experience in product, growth, and analytics at HubSpot, Reforge, and other high-growth companies." />

--- a/get-started.html
+++ b/get-started.html
@@ -9,6 +9,46 @@
   gtag('js', new Date());
   gtag('config', 'AW-1021884186');
 </script>
+<script>
+  // Google Ads conversion for "Start Free Trial" CTAs (links to my.work.coach).
+  // Fires the conversion, then follows the link once it registers (event_callback)
+  // so the ping isn't lost to navigation. Falls back if gtag is blocked/slow.
+  (function() {
+    function reportTrialConversion(url) {
+      var navigated = false;
+      var go = function () {
+        if (navigated) return;
+        navigated = true;
+        if (url) window.location = url;
+      };
+      try {
+        if (typeof gtag === 'function') {
+          gtag('event', 'conversion', {
+            'send_to': 'AW-1021884186/UYaXCOa_mbUcEJruoucD',
+            'event_callback': go
+          });
+          setTimeout(go, 1000); // fallback if the callback never fires
+        } else {
+          go();
+        }
+      } catch (e) {
+        go();
+      }
+    }
+
+    document.addEventListener('click', function(e) {
+      var link = e.target.closest ? e.target.closest('a[href^="https://my.work.coach"]') : null;
+      if (!link) return;
+      // Let new-tab / modified clicks open natively; still fire the conversion ping.
+      if (e.defaultPrevented || e.button !== 0 || e.metaKey || e.ctrlKey || e.shiftKey || e.altKey || link.target === '_blank') {
+        reportTrialConversion();
+        return;
+      }
+      e.preventDefault();
+      reportTrialConversion(link.href);
+    });
+  })();
+</script>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
 <meta name="description" content="Join the Work Coach waitlist. Tell us about yourself and what you want to get out of coaching.">
@@ -379,10 +419,8 @@ footer p { color: var(--muted); font-size: 14px; }
       posthog.capture('waitlist_submitted');
     }
 
-    // Google Ads conversion (same conversion used on /download)
-    if (typeof gtag === 'function') {
-      gtag('event', 'conversion', { 'send_to': 'AW-1021884186/UYaXCOa_mbUcEJruoucD' });
-    }
+    // Google Ads conversion now fires on the "Start Free Trial" CTAs (see <head>),
+    // not on waitlist submit.
 
     var data = Object.fromEntries(new FormData(form));
     data.source = 'work-coach-waitlist';

--- a/index.html
+++ b/index.html
@@ -9,6 +9,46 @@
   gtag('js', new Date());
   gtag('config', 'AW-1021884186');
 </script>
+<script>
+  // Google Ads conversion for "Start Free Trial" CTAs (links to my.work.coach).
+  // Fires the conversion, then follows the link once it registers (event_callback)
+  // so the ping isn't lost to navigation. Falls back if gtag is blocked/slow.
+  (function() {
+    function reportTrialConversion(url) {
+      var navigated = false;
+      var go = function () {
+        if (navigated) return;
+        navigated = true;
+        if (url) window.location = url;
+      };
+      try {
+        if (typeof gtag === 'function') {
+          gtag('event', 'conversion', {
+            'send_to': 'AW-1021884186/UYaXCOa_mbUcEJruoucD',
+            'event_callback': go
+          });
+          setTimeout(go, 1000); // fallback if the callback never fires
+        } else {
+          go();
+        }
+      } catch (e) {
+        go();
+      }
+    }
+
+    document.addEventListener('click', function(e) {
+      var link = e.target.closest ? e.target.closest('a[href^="https://my.work.coach"]') : null;
+      if (!link) return;
+      // Let new-tab / modified clicks open natively; still fire the conversion ping.
+      if (e.defaultPrevented || e.button !== 0 || e.metaKey || e.ctrlKey || e.shiftKey || e.altKey || link.target === '_blank') {
+        reportTrialConversion();
+        return;
+      }
+      e.preventDefault();
+      reportTrialConversion(link.href);
+    });
+  })();
+</script>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
 <meta name="description" content="Feedback to help you rock interviews, get a promotion, speak more confidently, and advocate for yourself. Work Coach observes the meetings you already have and shows you what to work on next.">

--- a/job-search.html
+++ b/job-search.html
@@ -9,6 +9,46 @@
   gtag('js', new Date());
   gtag('config', 'AW-1021884186');
 </script>
+<script>
+  // Google Ads conversion for "Start Free Trial" CTAs (links to my.work.coach).
+  // Fires the conversion, then follows the link once it registers (event_callback)
+  // so the ping isn't lost to navigation. Falls back if gtag is blocked/slow.
+  (function() {
+    function reportTrialConversion(url) {
+      var navigated = false;
+      var go = function () {
+        if (navigated) return;
+        navigated = true;
+        if (url) window.location = url;
+      };
+      try {
+        if (typeof gtag === 'function') {
+          gtag('event', 'conversion', {
+            'send_to': 'AW-1021884186/UYaXCOa_mbUcEJruoucD',
+            'event_callback': go
+          });
+          setTimeout(go, 1000); // fallback if the callback never fires
+        } else {
+          go();
+        }
+      } catch (e) {
+        go();
+      }
+    }
+
+    document.addEventListener('click', function(e) {
+      var link = e.target.closest ? e.target.closest('a[href^="https://my.work.coach"]') : null;
+      if (!link) return;
+      // Let new-tab / modified clicks open natively; still fire the conversion ping.
+      if (e.defaultPrevented || e.button !== 0 || e.metaKey || e.ctrlKey || e.shiftKey || e.altKey || link.target === '_blank') {
+        reportTrialConversion();
+        return;
+      }
+      e.preventDefault();
+      reportTrialConversion(link.href);
+    });
+  })();
+</script>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
 <meta name="description" content="Work Coach runs the job search with you. Get résumé feedback, interview practice tailored to each role, analysis of your real interviews, and help negotiating the offer.">

--- a/p/amplifyit.html
+++ b/p/amplifyit.html
@@ -9,6 +9,46 @@
   gtag('js', new Date());
   gtag('config', 'AW-1021884186');
 </script>
+<script>
+  // Google Ads conversion for "Start Free Trial" CTAs (links to my.work.coach).
+  // Fires the conversion, then follows the link once it registers (event_callback)
+  // so the ping isn't lost to navigation. Falls back if gtag is blocked/slow.
+  (function() {
+    function reportTrialConversion(url) {
+      var navigated = false;
+      var go = function () {
+        if (navigated) return;
+        navigated = true;
+        if (url) window.location = url;
+      };
+      try {
+        if (typeof gtag === 'function') {
+          gtag('event', 'conversion', {
+            'send_to': 'AW-1021884186/UYaXCOa_mbUcEJruoucD',
+            'event_callback': go
+          });
+          setTimeout(go, 1000); // fallback if the callback never fires
+        } else {
+          go();
+        }
+      } catch (e) {
+        go();
+      }
+    }
+
+    document.addEventListener('click', function(e) {
+      var link = e.target.closest ? e.target.closest('a[href^="https://my.work.coach"]') : null;
+      if (!link) return;
+      // Let new-tab / modified clicks open natively; still fire the conversion ping.
+      if (e.defaultPrevented || e.button !== 0 || e.metaKey || e.ctrlKey || e.shiftKey || e.altKey || link.target === '_blank') {
+        reportTrialConversion();
+        return;
+      }
+      e.preventDefault();
+      reportTrialConversion(link.href);
+    });
+  })();
+</script>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
 <meta name="description" content="An AI coach that finds out what's holding you back. Work Coach observes your meetings and gives you the feedback nobody tells you — filler words, missed agendas, coaching insights, and trends over time.">

--- a/p/index.html
+++ b/p/index.html
@@ -9,6 +9,46 @@
   gtag('js', new Date());
   gtag('config', 'AW-1021884186');
 </script>
+<script>
+  // Google Ads conversion for "Start Free Trial" CTAs (links to my.work.coach).
+  // Fires the conversion, then follows the link once it registers (event_callback)
+  // so the ping isn't lost to navigation. Falls back if gtag is blocked/slow.
+  (function() {
+    function reportTrialConversion(url) {
+      var navigated = false;
+      var go = function () {
+        if (navigated) return;
+        navigated = true;
+        if (url) window.location = url;
+      };
+      try {
+        if (typeof gtag === 'function') {
+          gtag('event', 'conversion', {
+            'send_to': 'AW-1021884186/UYaXCOa_mbUcEJruoucD',
+            'event_callback': go
+          });
+          setTimeout(go, 1000); // fallback if the callback never fires
+        } else {
+          go();
+        }
+      } catch (e) {
+        go();
+      }
+    }
+
+    document.addEventListener('click', function(e) {
+      var link = e.target.closest ? e.target.closest('a[href^="https://my.work.coach"]') : null;
+      if (!link) return;
+      // Let new-tab / modified clicks open natively; still fire the conversion ping.
+      if (e.defaultPrevented || e.button !== 0 || e.metaKey || e.ctrlKey || e.shiftKey || e.altKey || link.target === '_blank') {
+        reportTrialConversion();
+        return;
+      }
+      e.preventDefault();
+      reportTrialConversion(link.href);
+    });
+  })();
+</script>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
 <meta name="description" content="An AI coach that finds out what's holding you back. Work Coach observes your meetings and gives you the feedback nobody tells you — filler words, missed agendas, coaching insights, and trends over time.">


### PR DESCRIPTION
Previously the Google Ads conversion fired only on the get-started
waitlist form submit. Move it to fire on every 'Start Free Trial' CTA
(links to my.work.coach) across the site: index, get-started,
job-search, about, p/index, and p/amplifyit.

The handler mirrors the proven download.html pattern: it fires the
conversion and follows the link via event_callback with a timeout
fallback so the ping isn't lost to navigation, and lets new-tab /
modified clicks proceed natively while still pinging.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01HL1jNxjrNbsCHt1D3vQQkh