### PR TITLE
Remove Google Ads conversion tracking

### DIFF
--- a/360-feedback.html
+++ b/360-feedback.html
@@ -1,14 +1,6 @@
 <!doctype html>
 <html lang="en">
 <head>
-<!-- Google tag (gtag.js) -->
-<script async src="https://www.googletagmanager.com/gtag/js?id=AW-1021884186"></script>
-<script>
-  window.dataLayer = window.dataLayer || [];
-  function gtag(){dataLayer.push(arguments);}
-  gtag('js', new Date());
-  gtag('config', 'AW-1021884186');
-</script>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <meta name="description" content="See yourself through the eyes of your team. Get the structured 360 feedback you need to grow as a leader." />

--- a/404.html
+++ b/404.html
@@ -1,14 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-<!-- Google tag (gtag.js) -->
-<script async src="https://www.googletagmanager.com/gtag/js?id=AW-1021884186"></script>
-<script>
-  window.dataLayer = window.dataLayer || [];
-  function gtag(){dataLayer.push(arguments);}
-  gtag('js', new Date());
-  gtag('config', 'AW-1021884186');
-</script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta name="robots" content="noindex">

--- a/about.html
+++ b/about.html
@@ -1,54 +1,6 @@
 <!doctype html>
 <html lang="en">
 <head>
-<!-- Google tag (gtag.js) -->
-<script async src="https://www.googletagmanager.com/gtag/js?id=AW-1021884186"></script>
-<script>
-  window.dataLayer = window.dataLayer || [];
-  function gtag(){dataLayer.push(arguments);}
-  gtag('js', new Date());
-  gtag('config', 'AW-1021884186');
-</script>
-<script>
-  // Google Ads conversion for "Start Free Trial" CTAs (links to my.work.coach).
-  // Fires the conversion, then follows the link once it registers (event_callback)
-  // so the ping isn't lost to navigation. Falls back if gtag is blocked/slow.
-  (function() {
-    function reportTrialConversion(url) {
-      var navigated = false;
-      var go = function () {
-        if (navigated) return;
-        navigated = true;
-        if (url) window.location = url;
-      };
-      try {
-        if (typeof gtag === 'function') {
-          gtag('event', 'conversion', {
-            'send_to': 'AW-1021884186/UYaXCOa_mbUcEJruoucD',
-            'event_callback': go
-          });
-          setTimeout(go, 1000); // fallback if the callback never fires
-        } else {
-          go();
-        }
-      } catch (e) {
-        go();
-      }
-    }
-
-    document.addEventListener('click', function(e) {
-      var link = e.target.closest ? e.target.closest('a[href^="https://my.work.coach"]') : null;
-      if (!link) return;
-      // Let new-tab / modified clicks open natively; still fire the conversion ping.
-      if (e.defaultPrevented || e.button !== 0 || e.metaKey || e.ctrlKey || e.shiftKey || e.altKey || link.target === '_blank') {
-        reportTrialConversion();
-        return;
-      }
-      e.preventDefault();
-      reportTrialConversion(link.href);
-    });
-  })();
-</script>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <meta name="description" content="Dan Wolchonok has 20 years experience in product, growth, and analytics at HubSpot, Reforge, and other high-growth companies." />

--- a/download.html
+++ b/download.html
@@ -1,14 +1,6 @@
 <!doctype html>
 <html lang="en">
 <head>
-<!-- Google tag (gtag.js) -->
-<script async src="https://www.googletagmanager.com/gtag/js?id=AW-1021884186"></script>
-<script>
-  window.dataLayer = window.dataLayer || [];
-  function gtag(){dataLayer.push(arguments);}
-  gtag('js', new Date());
-  gtag('config', 'AW-1021884186');
-</script>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
 <meta name="description" content="Download Work Coach for Mac. An AI coach that finds out what's holding you back.">
@@ -988,31 +980,9 @@ footer {
   console.log('[WorkCoach] platform:', navigator.platform);
   console.log('[WorkCoach] isMobile:', isMobile, 'isMac:', isMac, 'isWindows:', isWindows);
 
-  // ─── Google Ads conversion tracking ───
-  // Fires the Download conversion, then navigates to `url` once the conversion
-  // has registered (via event_callback) so the ping isn't lost to navigation.
-  // Guarded with a fallback so a blocked/slow gtag never strands the download.
-  function gtag_report_conversion(url) {
-    var navigated = false;
-    var go = function () {
-      if (navigated) return;
-      navigated = true;
-      if (typeof url !== 'undefined') window.location = url;
-    };
-    try {
-      if (typeof gtag === 'function') {
-        gtag('event', 'conversion', {
-          'send_to': 'AW-1021884186/UYaXCOa_mbUcEJruoucD',
-          'event_callback': go
-        });
-        // Fallback in case the callback never fires (e.g. gtag blocked).
-        setTimeout(go, 1000);
-      } else {
-        go();
-      }
-    } catch (e) {
-      go();
-    }
+  // ─── Download navigation ───
+  function goToDownload(url) {
+    if (typeof url !== 'undefined') window.location = url;
     return false;
   }
 
@@ -1141,7 +1111,7 @@ footer {
       if (countdownEl) countdownEl.textContent = countdown;
       if (countdown <= 0) {
         clearInterval(timer);
-        gtag_report_conversion(DOWNLOAD_URL);
+        goToDownload(DOWNLOAD_URL);
       }
     }, 1000);
 
@@ -1150,7 +1120,7 @@ footer {
       e.preventDefault();
       clearInterval(timer);
       posthog.capture('download_manual_click');
-      gtag_report_conversion(this.href);
+      goToDownload(this.href);
     });
   }
 })();

--- a/english-at-work.html
+++ b/english-at-work.html
@@ -1,14 +1,6 @@
 <!doctype html>
 <html lang="en">
 <head>
-<!-- Google tag (gtag.js) -->
-<script async src="https://www.googletagmanager.com/gtag/js?id=AW-1021884186"></script>
-<script>
-  window.dataLayer = window.dataLayer || [];
-  function gtag(){dataLayer.push(arguments);}
-  gtag('js', new Date());
-  gtag('config', 'AW-1021884186');
-</script>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
 <meta name="description" content="For non-native English speakers. Work Coach helps you sound clear and confident at work: rehearse before meetings, find natural phrasing, review how you came across, and build the vocabulary your role needs.">

--- a/for-managers.html
+++ b/for-managers.html
@@ -1,14 +1,6 @@
 <!doctype html>
 <html lang="en">
 <head>
-<!-- Google tag (gtag.js) -->
-<script async src="https://www.googletagmanager.com/gtag/js?id=AW-1021884186"></script>
-<script>
-  window.dataLayer = window.dataLayer || [];
-  function gtag(){dataLayer.push(arguments);}
-  gtag('js', new Date());
-  gtag('config', 'AW-1021884186');
-</script>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
 <meta name="description" content="Work Coach is a coach for managers. It sits in on your 1:1s and team meetings, then helps you give clearer feedback, run better 1:1s, handle hard conversations, and develop each person on your team.">

--- a/get-promoted.html
+++ b/get-promoted.html
@@ -1,14 +1,6 @@
 <!doctype html>
 <html lang="en">
 <head>
-<!-- Google tag (gtag.js) -->
-<script async src="https://www.googletagmanager.com/gtag/js?id=AW-1021884186"></script>
-<script>
-  window.dataLayer = window.dataLayer || [];
-  function gtag(){dataLayer.push(arguments);}
-  gtag('js', new Date());
-  gtag('config', 'AW-1021884186');
-</script>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
 <meta name="description" content="Promotions are won in the months before review season. Work Coach benchmarks you against the next level, helps you close the gaps, build your case, and practice the ask.">

--- a/get-started.html
+++ b/get-started.html
@@ -1,54 +1,6 @@
 <!doctype html>
 <html lang="en">
 <head>
-<!-- Google tag (gtag.js) -->
-<script async src="https://www.googletagmanager.com/gtag/js?id=AW-1021884186"></script>
-<script>
-  window.dataLayer = window.dataLayer || [];
-  function gtag(){dataLayer.push(arguments);}
-  gtag('js', new Date());
-  gtag('config', 'AW-1021884186');
-</script>
-<script>
-  // Google Ads conversion for "Start Free Trial" CTAs (links to my.work.coach).
-  // Fires the conversion, then follows the link once it registers (event_callback)
-  // so the ping isn't lost to navigation. Falls back if gtag is blocked/slow.
-  (function() {
-    function reportTrialConversion(url) {
-      var navigated = false;
-      var go = function () {
-        if (navigated) return;
-        navigated = true;
-        if (url) window.location = url;
-      };
-      try {
-        if (typeof gtag === 'function') {
-          gtag('event', 'conversion', {
-            'send_to': 'AW-1021884186/UYaXCOa_mbUcEJruoucD',
-            'event_callback': go
-          });
-          setTimeout(go, 1000); // fallback if the callback never fires
-        } else {
-          go();
-        }
-      } catch (e) {
-        go();
-      }
-    }
-
-    document.addEventListener('click', function(e) {
-      var link = e.target.closest ? e.target.closest('a[href^="https://my.work.coach"]') : null;
-      if (!link) return;
-      // Let new-tab / modified clicks open natively; still fire the conversion ping.
-      if (e.defaultPrevented || e.button !== 0 || e.metaKey || e.ctrlKey || e.shiftKey || e.altKey || link.target === '_blank') {
-        reportTrialConversion();
-        return;
-      }
-      e.preventDefault();
-      reportTrialConversion(link.href);
-    });
-  })();
-</script>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
 <meta name="description" content="Join the Work Coach waitlist. Tell us about yourself and what you want to get out of coaching.">
@@ -417,9 +369,6 @@ footer p { color: var(--muted); font-size: 14px; }
     if (window.posthog) {
       posthog.capture('waitlist_submitted');
     }
-
-    // Google Ads conversion now fires on the "Start Free Trial" CTAs (see <head>),
-    // not on waitlist submit.
 
     var data = Object.fromEntries(new FormData(form));
     data.source = 'work-coach-waitlist';

--- a/index.html
+++ b/index.html
@@ -1,54 +1,6 @@
 <!doctype html>
 <html lang="en">
 <head>
-<!-- Google tag (gtag.js) -->
-<script async src="https://www.googletagmanager.com/gtag/js?id=AW-1021884186"></script>
-<script>
-  window.dataLayer = window.dataLayer || [];
-  function gtag(){dataLayer.push(arguments);}
-  gtag('js', new Date());
-  gtag('config', 'AW-1021884186');
-</script>
-<script>
-  // Google Ads conversion for "Start Free Trial" CTAs (links to my.work.coach).
-  // Fires the conversion, then follows the link once it registers (event_callback)
-  // so the ping isn't lost to navigation. Falls back if gtag is blocked/slow.
-  (function() {
-    function reportTrialConversion(url) {
-      var navigated = false;
-      var go = function () {
-        if (navigated) return;
-        navigated = true;
-        if (url) window.location = url;
-      };
-      try {
-        if (typeof gtag === 'function') {
-          gtag('event', 'conversion', {
-            'send_to': 'AW-1021884186/UYaXCOa_mbUcEJruoucD',
-            'event_callback': go
-          });
-          setTimeout(go, 1000); // fallback if the callback never fires
-        } else {
-          go();
-        }
-      } catch (e) {
-        go();
-      }
-    }
-
-    document.addEventListener('click', function(e) {
-      var link = e.target.closest ? e.target.closest('a[href^="https://my.work.coach"]') : null;
-      if (!link) return;
-      // Let new-tab / modified clicks open natively; still fire the conversion ping.
-      if (e.defaultPrevented || e.button !== 0 || e.metaKey || e.ctrlKey || e.shiftKey || e.altKey || link.target === '_blank') {
-        reportTrialConversion();
-        return;
-      }
-      e.preventDefault();
-      reportTrialConversion(link.href);
-    });
-  })();
-</script>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
 <meta name="description" content="Feedback to help you rock interviews, get a promotion, speak more confidently, and advocate for yourself. Work Coach observes the meetings you already have and shows you what to work on next.">

--- a/job-search.html
+++ b/job-search.html
@@ -1,54 +1,6 @@
 <!doctype html>
 <html lang="en">
 <head>
-<!-- Google tag (gtag.js) -->
-<script async src="https://www.googletagmanager.com/gtag/js?id=AW-1021884186"></script>
-<script>
-  window.dataLayer = window.dataLayer || [];
-  function gtag(){dataLayer.push(arguments);}
-  gtag('js', new Date());
-  gtag('config', 'AW-1021884186');
-</script>
-<script>
-  // Google Ads conversion for "Start Free Trial" CTAs (links to my.work.coach).
-  // Fires the conversion, then follows the link once it registers (event_callback)
-  // so the ping isn't lost to navigation. Falls back if gtag is blocked/slow.
-  (function() {
-    function reportTrialConversion(url) {
-      var navigated = false;
-      var go = function () {
-        if (navigated) return;
-        navigated = true;
-        if (url) window.location = url;
-      };
-      try {
-        if (typeof gtag === 'function') {
-          gtag('event', 'conversion', {
-            'send_to': 'AW-1021884186/UYaXCOa_mbUcEJruoucD',
-            'event_callback': go
-          });
-          setTimeout(go, 1000); // fallback if the callback never fires
-        } else {
-          go();
-        }
-      } catch (e) {
-        go();
-      }
-    }
-
-    document.addEventListener('click', function(e) {
-      var link = e.target.closest ? e.target.closest('a[href^="https://my.work.coach"]') : null;
-      if (!link) return;
-      // Let new-tab / modified clicks open natively; still fire the conversion ping.
-      if (e.defaultPrevented || e.button !== 0 || e.metaKey || e.ctrlKey || e.shiftKey || e.altKey || link.target === '_blank') {
-        reportTrialConversion();
-        return;
-      }
-      e.preventDefault();
-      reportTrialConversion(link.href);
-    });
-  })();
-</script>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
 <meta name="description" content="Work Coach runs the job search with you. Get résumé feedback, interview practice tailored to each role, analysis of your real interviews, and help negotiating the offer.">

--- a/macapp/checkout-cancel/index.html
+++ b/macapp/checkout-cancel/index.html
@@ -1,14 +1,6 @@
 <!doctype html>
 <html lang="en">
 <head>
-<!-- Google tag (gtag.js) -->
-<script async src="https://www.googletagmanager.com/gtag/js?id=AW-1021884186"></script>
-<script>
-  window.dataLayer = window.dataLayer || [];
-  function gtag(){dataLayer.push(arguments);}
-  gtag('js', new Date());
-  gtag('config', 'AW-1021884186');
-</script>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
 <meta name="robots" content="noindex">

--- a/macapp/checkout-success/index.html
+++ b/macapp/checkout-success/index.html
@@ -1,14 +1,6 @@
 <!doctype html>
 <html lang="en">
 <head>
-<!-- Google tag (gtag.js) -->
-<script async src="https://www.googletagmanager.com/gtag/js?id=AW-1021884186"></script>
-<script>
-  window.dataLayer = window.dataLayer || [];
-  function gtag(){dataLayer.push(arguments);}
-  gtag('js', new Date());
-  gtag('config', 'AW-1021884186');
-</script>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
 <meta name="robots" content="noindex">

--- a/macapp/index.html
+++ b/macapp/index.html
@@ -1,14 +1,6 @@
 <!doctype html>
 <html lang="en">
 <head>
-<!-- Google tag (gtag.js) -->
-<script async src="https://www.googletagmanager.com/gtag/js?id=AW-1021884186"></script>
-<script>
-  window.dataLayer = window.dataLayer || [];
-  function gtag(){dataLayer.push(arguments);}
-  gtag('js', new Date());
-  gtag('config', 'AW-1021884186');
-</script>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
 <meta name="robots" content="noindex">

--- a/manager-conversation.html
+++ b/manager-conversation.html
@@ -1,14 +1,6 @@
 <!doctype html>
 <html lang="en">
 <head>
-<!-- Google tag (gtag.js) -->
-<script async src="https://www.googletagmanager.com/gtag/js?id=AW-1021884186"></script>
-<script>
-  window.dataLayer = window.dataLayer || [];
-  function gtag(){dataLayer.push(arguments);}
-  gtag('js', new Date());
-  gtag('config', 'AW-1021884186');
-</script>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <meta name="description" content="How to get your manager to back Work Coach — the coaching that makes you a more self-directed report. A simple template that makes it easy (and often budget-friendly) for them to say yes." />

--- a/new-role.html
+++ b/new-role.html
@@ -1,14 +1,6 @@
 <!doctype html>
 <html lang="en">
 <head>
-<!-- Google tag (gtag.js) -->
-<script async src="https://www.googletagmanager.com/gtag/js?id=AW-1021884186"></script>
-<script>
-  window.dataLayer = window.dataLayer || [];
-  function gtag(){dataLayer.push(arguments);}
-  gtag('js', new Date());
-  gtag('config', 'AW-1021884186');
-</script>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
 <meta name="description" content="Work Coach helps you nail your first 90 days: build a 30-60-90 plan, learn the unwritten rules, make a strong first impression, and turn early meetings into momentum.">

--- a/p/amplifyit.html
+++ b/p/amplifyit.html
@@ -1,54 +1,6 @@
 <!doctype html>
 <html lang="en">
 <head>
-<!-- Google tag (gtag.js) -->
-<script async src="https://www.googletagmanager.com/gtag/js?id=AW-1021884186"></script>
-<script>
-  window.dataLayer = window.dataLayer || [];
-  function gtag(){dataLayer.push(arguments);}
-  gtag('js', new Date());
-  gtag('config', 'AW-1021884186');
-</script>
-<script>
-  // Google Ads conversion for "Start Free Trial" CTAs (links to my.work.coach).
-  // Fires the conversion, then follows the link once it registers (event_callback)
-  // so the ping isn't lost to navigation. Falls back if gtag is blocked/slow.
-  (function() {
-    function reportTrialConversion(url) {
-      var navigated = false;
-      var go = function () {
-        if (navigated) return;
-        navigated = true;
-        if (url) window.location = url;
-      };
-      try {
-        if (typeof gtag === 'function') {
-          gtag('event', 'conversion', {
-            'send_to': 'AW-1021884186/UYaXCOa_mbUcEJruoucD',
-            'event_callback': go
-          });
-          setTimeout(go, 1000); // fallback if the callback never fires
-        } else {
-          go();
-        }
-      } catch (e) {
-        go();
-      }
-    }
-
-    document.addEventListener('click', function(e) {
-      var link = e.target.closest ? e.target.closest('a[href^="https://my.work.coach"]') : null;
-      if (!link) return;
-      // Let new-tab / modified clicks open natively; still fire the conversion ping.
-      if (e.defaultPrevented || e.button !== 0 || e.metaKey || e.ctrlKey || e.shiftKey || e.altKey || link.target === '_blank') {
-        reportTrialConversion();
-        return;
-      }
-      e.preventDefault();
-      reportTrialConversion(link.href);
-    });
-  })();
-</script>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
 <meta name="description" content="An AI coach that finds out what's holding you back. Work Coach observes your meetings and gives you the feedback nobody tells you — filler words, missed agendas, coaching insights, and trends over time.">

--- a/p/index.html
+++ b/p/index.html
@@ -1,54 +1,6 @@
 <!doctype html>
 <html lang="en">
 <head>
-<!-- Google tag (gtag.js) -->
-<script async src="https://www.googletagmanager.com/gtag/js?id=AW-1021884186"></script>
-<script>
-  window.dataLayer = window.dataLayer || [];
-  function gtag(){dataLayer.push(arguments);}
-  gtag('js', new Date());
-  gtag('config', 'AW-1021884186');
-</script>
-<script>
-  // Google Ads conversion for "Start Free Trial" CTAs (links to my.work.coach).
-  // Fires the conversion, then follows the link once it registers (event_callback)
-  // so the ping isn't lost to navigation. Falls back if gtag is blocked/slow.
-  (function() {
-    function reportTrialConversion(url) {
-      var navigated = false;
-      var go = function () {
-        if (navigated) return;
-        navigated = true;
-        if (url) window.location = url;
-      };
-      try {
-        if (typeof gtag === 'function') {
-          gtag('event', 'conversion', {
-            'send_to': 'AW-1021884186/UYaXCOa_mbUcEJruoucD',
-            'event_callback': go
-          });
-          setTimeout(go, 1000); // fallback if the callback never fires
-        } else {
-          go();
-        }
-      } catch (e) {
-        go();
-      }
-    }
-
-    document.addEventListener('click', function(e) {
-      var link = e.target.closest ? e.target.closest('a[href^="https://my.work.coach"]') : null;
-      if (!link) return;
-      // Let new-tab / modified clicks open natively; still fire the conversion ping.
-      if (e.defaultPrevented || e.button !== 0 || e.metaKey || e.ctrlKey || e.shiftKey || e.altKey || link.target === '_blank') {
-        reportTrialConversion();
-        return;
-      }
-      e.preventDefault();
-      reportTrialConversion(link.href);
-    });
-  })();
-</script>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
 <meta name="description" content="An AI coach that finds out what's holding you back. Work Coach observes your meetings and gives you the feedback nobody tells you — filler words, missed agendas, coaching insights, and trends over time.">

--- a/privacy.html
+++ b/privacy.html
@@ -1,14 +1,6 @@
 <!doctype html>
 <html lang="en">
 <head>
-<!-- Google tag (gtag.js) -->
-<script async src="https://www.googletagmanager.com/gtag/js?id=AW-1021884186"></script>
-<script>
-  window.dataLayer = window.dataLayer || [];
-  function gtag(){dataLayer.push(arguments);}
-  gtag('js', new Date());
-  gtag('config', 'AW-1021884186');
-</script>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <meta name="description" content="Privacy Policy for Work Coach." />

--- a/support.html
+++ b/support.html
@@ -1,14 +1,6 @@
 <!doctype html>
 <html lang="en">
 <head>
-<!-- Google tag (gtag.js) -->
-<script async src="https://www.googletagmanager.com/gtag/js?id=AW-1021884186"></script>
-<script>
-  window.dataLayer = window.dataLayer || [];
-  function gtag(){dataLayer.push(arguments);}
-  gtag('js', new Date());
-  gtag('config', 'AW-1021884186');
-</script>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <meta name="description" content="Support for Work Coach." />


### PR DESCRIPTION
Removes the Google Ads / gtag.js conversion tracking ahead of moving conversion tracking into a separate repo. No GTM container or GA4 was present — only Google Ads (`AW-1021884186`).

## Changes (19 files, +5 / −422)
- **Base gtag.js head snippet** removed from all 19 HTML pages.
- **`reportTrialConversion` CTA handler** removed from the 6 pages that had it (`about`, `index`, `get-started`, `job-search`, `p/index`, `p/amplifyit`). It previously called `preventDefault()` on `my.work.coach` "Start Free Trial" links and navigated via the gtag callback — those links now navigate natively.
- **`download.html`**: `gtag_report_conversion` replaced with a gtag-free `goToDownload` helper. The download redirect and manual-link flows are preserved (the old function drove navigation, so it couldn't just be deleted).
- **`get-started.html`**: dropped the now-stale conversion comment.

## Not touched
- **PostHog** analytics (`posthog.capture(...)`) is a separate tool and is left in place.

## For the new repo
The conversion to re-create is `AW-1021884186/UYaXCOa_mbUcEJruoucD` — one shared conversion that fired on (a) Start Free Trial CTA clicks to `my.work.coach` and (b) the Mac download redirect.

## Verification
- `grep` for `gtag` / `googletagmanager` / `google ads` / `dataLayer` / `AW-` / `send_to` across all HTML → zero matches.
- Each page's `<head>` now goes straight from `<head>` to `<meta charset>`.
- `goToDownload` is defined and called at both download sites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)