### PR TITLE
Enrich 15 playbooks with podcast material and add 360-feedback playbook

### DIFF
--- a/404.html
+++ b/404.html
@@ -112,7 +112,7 @@
     <div id="fallback">
       <h1>Open in Coach</h1>
       <p>This link is meant to open in the Coach app. Download it to continue.</p>
-      <a href="https://work.coach/download" class="button">Download for Mac</a>
+      <a href="https://work.coach/download" class="button">Download</a>
       <br>
       <a id="manual-open" class="manual-link hidden">Try opening again</a>
     </div>

--- a/playbooks/apply-without-all-requirements.html
+++ b/playbooks/apply-without-all-requirements.html
@@ -602,6 +602,17 @@ footer p { color: var(--muted); font-size: 14px; }
   </ul>
 </div>
 
+<p>There's a mirror-image mistake worth naming: applying only where you match everything. Austin Belcak, who coaches job seekers at Cultivated Culture, points out that a role you're 100 percent qualified for is usually a lateral move, with little to grow into and little reason for the company to outbid what you're already making. He targets the 70 to 80 percent band instead: enough overlap to be credible, enough gap to justify the raise and the growth. And the band is worth remembering when you size up the competition:</p>
+
+<div class="nugget">
+  <p class="nugget-lead"><strong>The Dream Job System: why a 100% match is a warning sign.</strong> This one is audio only. The quote is at 2:28; the player starts from the top, or <a href="https://podcasts.apple.com/us/podcast/100-qualified-for-a-job-dont-apply-ep-673/id1542564331?i=1000700230781&t=148">open it on Apple Podcasts cued to 2:28</a>.</p>
+  <blockquote>"They're actually probably only 70 to 80% qualified for a lot of the roles that they really want. The truth is the candidates you're competing with are probably just as qualified as you are, which means you are more competitive than you think."</blockquote>
+  <div class="nugget-who"><strong>Austin Belcak</strong>, Cultivated Culture · The Dream Job System</div>
+  <div class="audio-embed">
+    <iframe src="https://embed.podcasts.apple.com/us/podcast/100-qualified-for-a-job-dont-apply-ep-673/id1542564331?i=1000700230781&theme=auto" height="175" frameborder="0" sandbox="allow-forms allow-popups allow-same-origin allow-scripts allow-top-navigation-by-user-activation" allow="autoplay *; encrypted-media *; clipboard-write" loading="lazy" title="The Dream Job System: 100% Qualified For A Job? Don't Apply - Apple Podcasts"></iframe>
+  </div>
+</div>
+
 <p>One thing worth saying about volume. A stretch application through the form has low odds on its own, and running twenty of them is a way to feel busy while learning nothing. Ten where you can answer the outcome question, with a person attached to each, does more.</p>
 
 <h2 id="what-beats-an-application-when-you-re-a-stretch">What beats an application when you're a stretch</h2>
@@ -694,6 +705,7 @@ footer p { color: var(--muted); font-size: 14px; }
     <li>Level Up: <a href="https://www.youtube.com/watch?v=_BY3DTlSbl0">How To Plan A Career Change, with Matt McCloskey</a> (Mar 2021)</li>
     <li>Lenny's Podcast: <a href="https://www.youtube.com/watch?v=v3pofqabzhs">Lessons from one of the world's top executive recruiters, with Lauren Ipsen</a> (Nov 2022)</li>
     <li>Lenny's Podcast: <a href="https://www.youtube.com/watch?v=OH3nzRdwYPA">Land your dream job in today's market, with Phyl Terry</a> (Sep 2024)</li>
+    <li>The Dream Job System (Austin Belcak): <a href="https://podcasts.apple.com/us/podcast/100-qualified-for-a-job-dont-apply-ep-673/id1542564331?i=1000700230781">100% Qualified For A Job? Don't Apply</a> (Mar 2025)</li>
   </ul>
 </div>
 

--- a/playbooks/ask-for-feedback-after-interview.html
+++ b/playbooks/ask-for-feedback-after-interview.html
@@ -445,6 +445,21 @@ footer p { color: var(--muted); font-size: 14px; }
 
 <p>If they name a gap and there's time, give one concise example that speaks to it. If the gap is real, say so and explain how you'd close it. Either way, listen without arguing. You're there to gather information about the decision, and pushing back turns a useful answer into a debate.</p>
 
+<p>Austin Belcak, who coaches job seekers at Cultivated Culture, sets this up even earlier, at the end of Q&amp;A: <em>"I really enjoyed this conversation and I want to be respectful of your time — would it be all right if I emailed you a couple more questions about the team?"</em> Nearly everyone says yes, and now you have a direct email address, an open channel that survives the interview, and a natural place for both the thank-you note and, later, the feedback request. Requests to an address they gave you land differently from requests routed through the recruiter.</p>
+
+<p>The first thing that channel carries is the thank-you note, sent the same day, and the math Belcak cites on those is lopsided:</p>
+
+<div class="nugget">
+  <p class="nugget-lead"><strong>The Dream Job System: why thank-you notes still count.</strong> This one is audio only. The quote is at 1:09; the player starts from the top, or <a href="https://podcasts.apple.com/us/podcast/how-to-write-a-job-winning-thank-you-note-ep-660/id1542564331?i=1000693904293&t=69">open it on Apple Podcasts cued to 1:09</a>.</p>
+  <blockquote>"A recent survey found that 80% of hiring managers found thank you notes helpful when making their hiring decisions, but only 24% of job seekers actually take the time to write one."</blockquote>
+  <div class="nugget-who"><strong>Austin Belcak</strong>, Cultivated Culture · The Dream Job System</div>
+  <div class="audio-embed">
+    <iframe src="https://embed.podcasts.apple.com/us/podcast/how-to-write-a-job-winning-thank-you-note-ep-660/id1542564331?i=1000693904293&theme=auto" height="175" frameborder="0" sandbox="allow-forms allow-popups allow-same-origin allow-scripts allow-top-navigation-by-user-activation" allow="autoplay *; encrypted-media *; clipboard-write" loading="lazy" title="The Dream Job System: How To Write A Job-Winning Thank You Note - Apple Podcasts"></iframe>
+  </div>
+</div>
+
+<p>Send it by email, which 87 percent of hiring managers prefer (Accountemps). Three sentences is enough: the thanks, one specific detail from the conversation, and your excitement. The specific detail is what turns it from a formality into a data point about you.</p>
+
 <h2 id="after-a-rejection-make-the-request-easy-to-answer">After a rejection, make the request easy to answer</h2>
 
 <p>Reply within one business day, while the interviews are still fresh for everyone. Keep the note to four parts: thanks, something you genuinely liked about the process, one narrow question, and explicit permission to decline. "Can you give me any feedback?" asks a busy recruiter to write a performance review. A recruiter can answer a narrow question in one sentence from their phone.</p>
@@ -585,6 +600,8 @@ footer p { color: var(--muted); font-size: 14px; }
     <li>Lenny's Podcast: <a href="https://www.youtube.com/watch?v=OH3nzRdwYPA">Land your dream job in today's market, with Phyl Terry</a> (Sep 2024)</li>
     <li>Lenny's Podcast: <a href="https://www.youtube.com/watch?v=v3pofqabzhs">Lessons from one of the world's top executive recruiters, with Lauren Ipsen</a> (Nov 2022)</li>
     <li>Lenny's Podcast: <a href="https://www.youtube.com/watch?v=LpbBzmXrzEY">How to speak more confidently and persuasively, with Matt Abrahams</a> (Mar 2024)</li>
+    <li>The Dream Job System (Austin Belcak): <a href="https://podcasts.apple.com/us/podcast/9-unique-questions-to-ask-in-your-next-interview-ep-728/id1542564331?i=1000719458230">9 Unique Questions To Ask In Your Next Interview</a> (Jul 2025)</li>
+    <li>The Dream Job System (Austin Belcak): <a href="https://podcasts.apple.com/us/podcast/how-to-write-a-job-winning-thank-you-note-ep-660/id1542564331?i=1000693904293">How To Write A Job-Winning Thank You Note</a> (Feb 2025)</li>
   </ul>
 </div>
 

--- a/playbooks/ask-for-job-referral.html
+++ b/playbooks/ask-for-job-referral.html
@@ -419,7 +419,7 @@ footer p { color: var(--muted); font-size: 14px; }
   <div class="post-kicker">Job Search</div>
   <h1>How to ask for a job referral without making it feel transactional</h1>
   <p class="post-sub">Give the person enough context to make an honest choice and enough material to help you in two minutes.</p>
-  <div class="post-meta">9 min read</div>
+  <div class="post-meta">10 min read</div>
 </div>
 
 <main class="layout">
@@ -456,6 +456,27 @@ footer p { color: var(--muted); font-size: 14px; }
 </div>
 <p>Terry adds, about a minute later in the same answer, that when you ask for help this way and you've clearly done your homework, people want to help you even more and "become invested in you." That's the opposite of what most people fear the ask will do to the relationship.</p>
 <p>After the conversation, you can ask directly: "Do you feel you have enough context on my background to recommend a next step, or refer me?" If they hesitate, take the signal. They may offer a different role, another contact, or a way to strengthen your application, and any of those is worth more than a lukewarm referral.</p>
+<p>The most systematic version of context building we've seen comes from Austin Belcak, who coaches job seekers at Cultivated Culture. He built it for the contact who has no content to engage with, and for the feeling that you have nothing to offer someone senior. He calls it the Advice Triangle, and it has three sides.</p>
+<div class="callout">
+<h4>The Advice Triangle</h4>
+<ul>
+<li><strong>Ask for advice as a binary choice.</strong> Position them as the expert and offer two concrete options you pre-selected, both finishable inside two weeks: <em>"I'm looking to sharpen my skills as a [role]. If you were advising someone, would you (a) read [specific book] or (b) take [specific course]? All you have to do is say A or B — I know your time is valuable."</em> A binary beats "any advice for me?" because answering costs ten seconds.</li>
+<li><strong>Actually do the thing.</strong> Most people who ask for advice vanish. Doing it is the differentiator.</li>
+<li><strong>Close the triangle.</strong> Report back with two or three concrete takeaways and what changed for you, then ask for the next piece of advice.</li>
+</ul>
+</div>
+<p>After two or three loops you have a real relationship: they've shaped your path, you've shown them their advice mattered, and by then most people genuinely want to see you land well. Only then comes the ask, and it stays soft: <em>"Things are changing on my end and I'm in the market for something new. If you hear of anything, I'd appreciate you keeping me in mind."</em></p>
+
+<div class="nugget">
+  <p class="nugget-lead"><strong>The Dream Job System: the advice triangle.</strong> This one is audio only. The quote is at 1:28; the player starts from the top, or <a href="https://podcasts.apple.com/us/podcast/my-advice-triangle-strategy-to-network-with-anyone-ep-257/id1542564331?i=1000570775712&t=88">open it on Apple Podcasts cued to 1:28</a>.</p>
+  <blockquote>"It's actually almost more effective if you have less experience than the person that you're talking to."</blockquote>
+  <div class="nugget-who"><strong>Austin Belcak</strong>, Cultivated Culture · The Dream Job System</div>
+  <div class="audio-embed">
+    <iframe src="https://embed.podcasts.apple.com/us/podcast/my-advice-triangle-strategy-to-network-with-anyone-ep-257/id1542564331?i=1000570775712&theme=auto" height="175" frameborder="0" sandbox="allow-forms allow-popups allow-same-origin allow-scripts allow-top-navigation-by-user-activation" allow="autoplay *; encrypted-media *; clipboard-write" loading="lazy" title="The Dream Job System: My &quot;Advice Triangle&quot; Strategy To Network With Anyone - Apple Podcasts"></iframe>
+  </div>
+</div>
+
+<p>His outreach mechanics for reaching these contacts in the first place are in the <a href="/playbooks/get-foot-in-door-at-company">foot-in-the-door playbook</a>.</p>
 
 <h2 id="use-double-opt-in-for-introductions">Use double opt-in for introductions</h2>
 <p>Matt Mochary's rule for introductions: the connector first forwards your request privately and asks the recipient one question, "Interested?" The two of you get connected only after the recipient says yes. Nobody ends up trapped in a thread they didn't agree to join.</p>
@@ -500,6 +521,7 @@ footer p { color: var(--muted); font-size: 14px; }
   </div>
 </div>
 <p>If someone does refer you, keep them informed: when the company responds, before a big interview, and when the process ends either way. Thank them for the action they took regardless of the outcome. And months later, when you have something genuinely useful to share, share it. Don't disappear the day you sign an offer.</p>
+<p>Belcak's targeting filter keeps the whole thing from feeling transactional, because it fixes who's on the list in the first place. His test before any outreach: would I want this person in my network even if no job ever comes of it? He picks contacts by writing down the criteria of the life he's aiming at, the companies, the city, the autonomy, the income, and finding people who already live it. The referral stops being the goal and becomes a byproduct, which is also exactly how it reads on the other end.</p>
 
 <h2 id="the-messages-word-for-word">The messages, word for word</h2>
 <p>Adjust the details, but keep the shape: name the role, say why they specifically can speak to your work, and make declining easy.</p>
@@ -562,6 +584,8 @@ footer p { color: var(--muted); font-size: 14px; }
 <li>Lenny's Podcast: <a href="https://www.youtube.com/watch?v=OH3nzRdwYPA">Land your dream job in today's market, with Phyl Terry</a> (Sep 2024)</li>
 <li>Lenny's Podcast: <a href="https://www.youtube.com/watch?v=v3pofqabzhs">Lessons from one of the world's top executive recruiters, with Lauren Ipsen</a> (Nov 2022)</li>
 <li>Mochary Method curriculum: <a href="https://docs.google.com/document/d/19FWxzeYzjqW-6l-5GsTAB5QgD2ITuW0XWeQxh_7sptg/edit">Introductions: the Double Opt-In</a></li>
+<li>The Dream Job System (Austin Belcak): <a href="https://podcasts.apple.com/us/podcast/my-advice-triangle-strategy-to-network-with-anyone-ep-257/id1542564331?i=1000570775712">My "Advice Triangle" Strategy To Network With Anyone</a> (Jul 2022)</li>
+<li>The Dream Job System (Austin Belcak): <a href="https://podcasts.apple.com/us/podcast/effective-networking-is-making-friends-not-asking-for/id1542564331?i=1000533060772">Effective Networking Is Making Friends, Not Asking For A Job</a> (Aug 2021)</li>
 </ul>
 </div>
 

--- a/playbooks/behavioral-interview-questions.html
+++ b/playbooks/behavioral-interview-questions.html
@@ -419,7 +419,7 @@ footer p { color: var(--muted); font-size: 14px; }
   <div class="post-kicker">Interview Prep</div>
   <h1>Behavioral interview questions: how top operators actually answer them</h1>
   <p class="post-sub">Leaders at Stripe, Ramp, Intercom, and Meta have explained on the record what they ask candidates and what they listen for. Here is what they said, with links to the exact moments.</p>
-  <div class="post-meta">12 min read</div>
+  <div class="post-meta">13 min read</div>
 </div>
 
 <main class="layout">
@@ -538,6 +538,29 @@ footer p { color: var(--muted); font-size: 14px; }
   <div class="nugget-who"><strong>Shaan Puri</strong> · My First Million, "5 Hacks to Landing Your Dream Job" (10:20)</div>
 </div>
 
+<p>Austin Belcak, who coaches job seekers at Cultivated Culture, adds two refinements to how a STAR answer starts and ends. STAR answers fall flat in two places, he argues. They start nowhere, opening cold on a situation the interviewer has no reason to care about, and they end at the expected result, the deal saved or the deadline met, which is exactly where the interviewer assumed the story was going.</p>
+
+<div class="callout">
+  <h4>The 4-Part Anatomy of a Strong Answer</h4>
+  <ul>
+    <li><strong>Tie the example to this role up front.</strong> One sentence showing you know why this hire matters and what the team's goals are, before the story starts.</li>
+    <li><strong>Set the stakes with numbers.</strong> A story about saving a $10M deal lands harder than a story about saving "a client."</li>
+    <li><strong>Show your work as a highlight reel.</strong> The three or four decisions that led to the outcome, not a blow-by-blow.</li>
+    <li><strong>End past the expected result.</strong> The win the story promised, plus the extra ones you layered on top of it.</li>
+  </ul>
+</div>
+
+<div class="nugget">
+  <p class="nugget-lead"><strong>The Dream Job System: the 4-part anatomy of a great interview answer.</strong> This one is audio only. The quote is at 4:49; the player starts from the top, or <a href="https://podcasts.apple.com/us/podcast/the-4-part-anatomy-of-a-great-interview-answer-ep-770/id1542564331?i=1000734998826&t=289">open it on Apple Podcasts cued to 4:49</a>.</p>
+  <blockquote>"The more wins that you can layer on here, the better. Because what that shows is it sets the precedent that you don't just stop at the expected outcome. You go above and beyond to find multiple solutions."</blockquote>
+  <div class="nugget-who"><strong>Austin Belcak</strong>, Cultivated Culture · The Dream Job System</div>
+  <div class="audio-embed">
+    <iframe src="https://embed.podcasts.apple.com/us/podcast/the-4-part-anatomy-of-a-great-interview-answer-ep-770/id1542564331?i=1000734998826&theme=auto" height="175" frameborder="0" sandbox="allow-forms allow-popups allow-same-origin allow-scripts allow-top-navigation-by-user-activation" allow="autoplay *; encrypted-media *; clipboard-write" loading="lazy" title="The Dream Job System: The 4 Part Anatomy Of A Great Interview Answer - Apple Podcasts"></iframe>
+  </div>
+</div>
+
+<p>The fourth part is where his model answer separates itself. A $10M deal at risk became a $20M extension, 316% over the original, plus a standardized process so the same failure never happened again. The extension is the result everyone expected; the extra wins are the signal that you don't stop at the expected outcome.</p>
+
 <h2 id="practice-telling-your-story-before-interview-ten">Practice telling your story before interview ten</h2>
 
 <p>Lauren Ipsen recruits executives for Daversa Partners, one of tech's top search firms. She sees hundreds of candidates work through the same behavioral questions, and she names the two most common failures.</p>
@@ -578,6 +601,14 @@ footer p { color: var(--muted); font-size: 14px; }
 <p>This mirrors how the best hiring managers already operate. Mochary's curriculum tells managers to write a new hire's first-90-days goals before they even start recruiting. When you show up talking about the outcomes you would own in your first two quarters, you are answering the question they wrote down before they met you.</p>
 
 <p>Terry also gives candidates a behavioral question to ask the interviewer (1:42:57 in the same episode): "Tell me about a time the company brought in a senior person and it failed." Senior hires fail often, the answer tells you why they fail here, and asking it signals you think about roles the way an owner does.</p>
+
+<p>The mirror image of writing the job description yourself is reverse-engineering the one they wrote. Belcak's method: go through the job description line by line, and for every requirement, write the question an interviewer would ask to probe it. "Responsible for creating partnerships with cloud-based SaaS companies" becomes "tell me about a technology partnership you facilitated." A member of his community reverse-engineered a Google job description this way and spent ten hours preparing for the phone screen alone, against the two hours or less that most candidates report spending on an entire interview. He got the offer.</p>
+
+<h3>Mine the questions they actually asked</h3>
+
+<p>Prediction covers the questions they should ask. Glassdoor covers the ones they actually do: the Interviews tab lists real questions reported by real candidates at the specific company. Filter by the job title you're interviewing for, or adjacent titles if the list runs thin, copy every reported question into a spreadsheet, and tally the repeats. A question reported five times is a question you'll probably get.</p>
+
+<p>Some reviews also note whether the person got the offer. When you find an answer from someone who did, mirror its structure. A couple of hours of mining turns "what might they ask" into a ranked list.</p>
 
 <h2 id="one-more-filter-expect-the-anti-sell">One more filter: expect the anti-sell</h2>
 
@@ -620,6 +651,9 @@ footer p { color: var(--muted); font-size: 14px; }
     <li>My First Million: <a href="https://podcasts.apple.com/us/podcast/mfm-mini-5-hacks-to-landing-your-dream-job/id1469759170?i=1000530644834">5 Hacks to Landing Your Dream Job</a> (Aug 2021, audio)</li>
     <li>The Skip Podcast: <a href="https://www.youtube.com/watch?v=jYO7FupLvAM">Mastering your 30 second resume</a> (Sep 2024)</li>
     <li>The Mochary Method curriculum: <a href="https://docs.google.com/document/d/1zHHQok1GAPpUdx_apA_M6RWB7753zbBhac8-9H2dG_M/edit">recruiting and onboarding</a>, and <a href="https://docs.google.com/document/d/1iK7OMMBbmvpzwfsumKde2tbO3MFLSSDU715-Yv3oOOA/edit">the anti-sell</a></li>
+    <li>The Dream Job System (Austin Belcak): <a href="https://podcasts.apple.com/us/podcast/the-4-part-anatomy-of-a-great-interview-answer-ep-770/id1542564331?i=1000734998826">The 4 Part Anatomy Of A Great Interview Answer</a> (Nov 2025)</li>
+    <li>The Dream Job System (Austin Belcak): <a href="https://podcasts.apple.com/us/podcast/a-4-step-framework-for-highly-effective-interview/id1542564331?i=1000776224786">A 4 Step Framework For Highly Effective Interview Prep</a> (Jul 2026)</li>
+    <li>The Dream Job System (Austin Belcak): <a href="https://podcasts.apple.com/us/podcast/how-to-anticipate-every-interview-question-in-3-steps-ep-842/id1542564331?i=1000769775701">How To Anticipate Every Interview Question In 3 Steps</a> (May 2026)</li>
   </ul>
 </div>
 

--- a/playbooks/explain-career-gap-in-interview.html
+++ b/playbooks/explain-career-gap-in-interview.html
@@ -419,7 +419,7 @@ footer p { color: var(--muted); font-size: 14px; }
   <div class="post-kicker">Interview Prep</div>
   <h1>How to explain a career gap in an interview</h1>
   <p class="post-sub">The answer is shorter than you think, and the interviewer cares about less of it than you fear. Here's how to say it once and move on.</p>
-  <div class="post-meta">12 min read</div>
+  <div class="post-meta">13 min read</div>
 </div>
 
 <main class="layout">
@@ -508,6 +508,22 @@ footer p { color: var(--muted); font-size: 14px; }
 
 <p>Then be quiet. The silence after a short answer feels much longer to you than to them, and filling it is where people talk themselves into trouble. If you want more on the opening story this connects to, the <a href="/playbooks/tell-me-about-yourself-interview-answer">tell me about yourself playbook</a> covers the two-minute version of your whole arc.</p>
 
+<div class="callout">
+  <h4>Two Registers for the Answer</h4>
+  <p>Saying it once and stopping is still the rule. Austin Belcak, who coaches job seekers at Cultivated Culture, offers two worked versions of the short answer, one for each register, and both end somewhere deliberate so the stop doesn't feel like a stall.</p>
+  <p><strong>If you did:</strong> one line on the gap, then pivot straight to the evidence. <em>"I was part of a restructuring that let 300 people go. I wanted to come back an even stronger account manager, so here's what I did with the time: [the course, the book, the conference]."</em></p>
+  <p><strong>If you didn't:</strong> close the loop and hand the conversation back. <em>"I took that time for personal reasons, and my skills are as sharp as they were — I'm fully up to speed on the current tools. What I'm most excited about is this role: preparing for this interview I listened to an interview with your CEO, and the direction they described lines up with exactly where I want to go."</em> The ending matters: it gives the interviewer a hook to pick up, so no awkward pause invites a follow-up interrogation of the gap.</p>
+</div>
+
+<div class="nugget">
+  <p class="nugget-lead"><strong>The Dream Job System: one line on the gap, then the positives.</strong> This one is audio only. The quote is at 6:42; the player starts from the top, or <a href="https://podcasts.apple.com/us/podcast/how-to-easily-explain-a-gap-in-employment-ep-735/id1542564331?i=1000721767999&t=402">open it on Apple Podcasts cued to 6:42</a>.</p>
+  <blockquote>"Now we have one line that explains the gap, but then we focus on the positives and we can showcase what we did to improve."</blockquote>
+  <div class="nugget-who"><strong>Austin Belcak</strong>, Cultivated Culture · The Dream Job System</div>
+  <div class="audio-embed">
+    <iframe src="https://embed.podcasts.apple.com/us/podcast/how-to-easily-explain-a-gap-in-employment-ep-735/id1542564331?i=1000721767999&theme=auto" height="175" frameborder="0" sandbox="allow-forms allow-popups allow-same-origin allow-scripts allow-top-navigation-by-user-activation" allow="autoplay *; encrypted-media *; clipboard-write" loading="lazy" title="The Dream Job System: How To Easily Explain A Gap In Employment - Apple Podcasts"></iframe>
+  </div>
+</div>
+
 <h2 id="what-you-did-with-the-time-matters-more-than-how-long-it-was">What you did with the time matters more than how long it was</h2>
 
 <p>The middle beat is the one people skimp on, and it's the one doing the most work. Nikhyl Singhal spent an episode of The Skip on how hiring managers read early-career resumes, and his comparison applies at any level. Two candidates with similar gaps get read completely differently based on what they can describe.</p>
@@ -537,6 +553,7 @@ footer p { color: var(--muted); font-size: 14px; }
 <p>Use years instead of months on your resume if that closes a gap of a few months honestly. If it's longer, put a line in your work history for what you were doing, with dates, the same way you'd list a job: "Career break, caregiving, 2024 to 2025" or "Independent consulting, 2024 to present," with a bullet or two of real work underneath. Recruiters skimming for continuity will read that and keep going. An unexplained blank is what makes them slow down and guess.</p>
 
 <p>On LinkedIn, the Career Break entry exists for exactly this and using it is fine. Add a reason if you have one you're comfortable naming, and set your headline to what you do rather than to your last employer, so people see the work and not the exit. If you were part of a public layoff, a short post about it is worth doing, because recruiters search those threads.</p>
+
 
 <p>Two things to avoid. Don't stretch dates, because background checks compare against payroll records and a fudge that gets caught costs you the offer. And don't leave your last role open-ended if it has ended, because that looks like an oversight and earns you a suspicious first question. If you're also changing fields, the <a href="/playbooks/resume-for-career-change">resume for a career change playbook</a> covers how to make the whole document tell one story.</p>
 
@@ -695,6 +712,7 @@ footer p { color: var(--muted); font-size: 14px; }
     <li>Lenny's Podcast: <a href="https://www.youtube.com/watch?v=v3pofqabzhs">Lessons from one of the world's top executive recruiters, with Lauren Ipsen</a> (Nov 2022)</li>
     <li>Lenny's Podcast: <a href="https://www.youtube.com/watch?v=MajB5CQUKDA">Succeeding as an introvert and PM'ing your career like a product, with Deb Liu</a> (Aug 2024)</li>
     <li>Working It (Financial Times): The unintended consequences of mass layoffs (Mar 2023, audio)</li>
+    <li>The Dream Job System (Austin Belcak): <a href="https://podcasts.apple.com/us/podcast/how-to-easily-explain-a-gap-in-employment-ep-735/id1542564331?i=1000721767999">How To Easily Explain A Gap In Employment</a> (Aug 2025)</li>
   </ul>
 </div>
 

--- a/playbooks/get-foot-in-door-at-company.html
+++ b/playbooks/get-foot-in-door-at-company.html
@@ -419,7 +419,7 @@ footer p { color: var(--muted); font-size: 14px; }
   <div class="post-kicker">Job Search</div>
   <h1>How to get your foot in the door at a company</h1>
   <p class="post-sub">Recruiters aren't responding and your application is sitting in a queue. Here's how to build several credible paths to the team instead of waiting on one.</p>
-  <div class="post-meta">11 min read</div>
+  <div class="post-meta">13 min read</div>
 </div>
 
 <main class="layout">
@@ -443,6 +443,17 @@ footer p { color: var(--muted); font-size: 14px; }
 </ol>
 
 <p>Ten names with a reason to reply are more useful than a hundred scraped contacts.</p>
+
+<p>Most of that map lives on LinkedIn, and most people only ever use the search bar to look up names they already know. Austin Belcak, who coaches job seekers at Cultivated Culture, runs three searches that surface the names you don't know yet.</p>
+
+<div class="callout">
+  <h4>Three LinkedIn searches most people never run</h4>
+  <ul>
+    <li><strong>People who made your exact move.</strong> Search the target job title, switch to the People filter, set Current companies to your target companies and Past companies to companies in your current industry. Everyone in the results made the transition you're attempting, and the outreach opens itself: <em>"I saw you moved from X to Y — I'm trying to make the same move."</em></li>
+    <li><strong>Who's hiring right now.</strong> Search the job title plus the word "hiring," filter to Posts, then filter the author's company to your targets. The recent posts are hiring managers announcing openings, a direct line that skips the application pile.</li>
+    <li><strong>A less filtered culture read.</strong> Run a blank search and set Past companies to the target. Ex-employees who left for a step up tend to talk more freely than anyone still inside. Still one perspective, so collect a few.</li>
+  </ul>
+</div>
 
 <h2 id="start-with-a-listening-tour">Start with a listening tour</h2>
 
@@ -541,9 +552,29 @@ footer p { color: var(--muted); font-size: 14px; }
 
 <p>Be selective. Five researched notes to relevant people leave you time to personalize each one and follow up properly, which a hundred templated messages never do.</p>
 
+<p>Belcak teaches the same principles with exact wording attached. His three rules: make the message about them, never ask for more than a conversation, and give them an out. Making it about them means finding an angle in their profile, their content, or their career path, one thing you can name in a specific sentence. The first few feel slow, but after a couple dozen reps finding an angle takes about 30 seconds. And the ask stays small on purpose, no resume attached, no "can you refer me," just a conversation.</p>
+
+<div class="callout">
+  <h4>Belcak's outreach skeleton</h4>
+  <p><em>"Hi [name] — I came across your info while looking for people who [the angle: made the transition from healthcare into tech / built a real presence in the career space]. Your experience stood out because [one specific sentence]. I'd love to ask you a few questions about your journey. I know you're busy and this is a big ask from a stranger — if you have a few minutes I'd be grateful, and if not, I completely understand. Either way, I hope you have a great week."</em></p>
+</div>
+
+<p>The closing line is the part Belcak refuses to cut, and he credits it with tripling his response rates: the explicit permission to say no, "if not, I completely understand," is what separates this note from the "Thanks in advance!" and Calendly-link messages that read as entitled. His test before sending anything: if you received this email from a stranger, would you reply?</p>
+
+<div class="nugget">
+  <p class="nugget-lead"><strong>The Dream Job System: the outreach email and the exit clause.</strong> This one is audio only. The quote is at 3:20; the player starts from the top, or <a href="https://podcasts.apple.com/us/podcast/this-is-the-exact-outreach-email-i-use-with-my-clients-ep-835/id1542564331?i=1000767147027&t=200">open it on Apple Podcasts cued to 3:20</a>.</p>
+  <blockquote>"The sole goal of your initial outreach should simply be to get the person to respond and start a dialogue. Then my third rule is to remove the pressure by giving them an out. I call this an exit clause."</blockquote>
+  <div class="nugget-who"><strong>Austin Belcak</strong>, Cultivated Culture · The Dream Job System</div>
+  <div class="audio-embed">
+    <iframe src="https://embed.podcasts.apple.com/us/podcast/this-is-the-exact-outreach-email-i-use-with-my-clients-ep-835/id1542564331?i=1000767147027&theme=auto" height="175" frameborder="0" sandbox="allow-forms allow-popups allow-same-origin allow-scripts allow-top-navigation-by-user-activation" allow="autoplay *; encrypted-media *; clipboard-write" loading="lazy" title="The Dream Job System: This Is The Exact Outreach Email I Use With My Clients - Apple Podcasts"></iframe>
+  </div>
+</div>
+
 <h2 id="contact-the-hiring-manager-with-evidence">Contact the hiring manager with evidence</h2>
 
 <p>Apply through the official channel first unless the posting says otherwise. Then send one short note to the likely hiring manager. Name the exact role, one outcome you've delivered that resembles the work, and one useful question.</p>
+
+<p>Finding the address is easier than it looks. Belcak's method starts with an email lookup tool (Hunter, MailScoop, RocketReach), which takes a name plus the company domain and returns a confidence score. When the tools miss, reverse-engineer the pattern: run a domain-only search to see how existing addresses are shaped, first initial plus last name versus first.last, or find a salesperson at the company on LinkedIn, since salespeople publish their emails. Between the tools and the pattern, he puts the hit rate at 80 to 90 percent.</p>
 
 <div class="callout">
   <h4>Hiring manager message</h4>
@@ -566,6 +597,19 @@ footer p { color: var(--muted); font-size: 14px; }
     <li>Send five researched direct messages.</li>
     <li>Make one useful follow-up to an existing relationship.</li>
     <li>Review replies and improve your weakest message.</li>
+  </ul>
+</div>
+
+<p>Before adding strangers to the map, mine your own LinkedIn inbox 12 to 24 months back for recruiters who once messaged you, and revive the dormant thread: <em>"You reached out X months ago about a role at [company]. The timing wasn't right then, but I'm in the market now — do you have anything focused on [target role]?"</em> Recruiters are paid to fill pipelines; dormant threads revive at a startling rate.</p>
+
+<p>Belcak keeps the weekly cadence honest with a spreadsheet he calls a Dream 100, though in practice, he says, a "Dream 30" is plenty. One person on the list gets a small, no-ask touch each day, a comment on their post, a useful link, an introduction. At 30 people that works out to one touch per person per month, the same stay-known cadence described earlier, with a system behind it so it actually happens.</p>
+
+<div class="callout">
+  <h4>The Dream 30 spreadsheet</h4>
+  <ul>
+    <li>Columns for name, title, company, and date of last touch.</li>
+    <li>A notes column seeded with connection clues: shared school, a talk they gave, what they post about.</li>
+    <li>One person a day, one small touch, no ask attached.</li>
   </ul>
 </div>
 
@@ -625,6 +669,12 @@ footer p { color: var(--muted); font-size: 14px; }
     <li>Lenny's Podcast: <a href="https://www.youtube.com/watch?v=OH3nzRdwYPA">Land your dream job in today's market, with Phyl Terry</a> (Sep 2024)</li>
     <li>Lenny's Podcast: <a href="https://www.youtube.com/watch?v=v3pofqabzhs">Lessons from one of the world's top executive recruiters, with Lauren Ipsen</a> (Nov 2022)</li>
     <li>Mochary Method: <a href="https://docs.google.com/document/d/19FWxzeYzjqW-6l-5GsTAB5QgD2ITuW0XWeQxh_7sptg/edit">Introductions: the Double Opt-In</a></li>
+    <li>The Dream Job System (Austin Belcak): <a href="https://podcasts.apple.com/us/podcast/this-is-the-exact-outreach-email-i-use-with-my-clients-ep-835/id1542564331?i=1000767147027">This Is The Exact Outreach Email I Use With My Clients</a> (May 2026)</li>
+    <li>The Dream Job System (Austin Belcak): <a href="https://podcasts.apple.com/us/podcast/triple-your-response-rates-using-an-exit-clause-ep-537/id1542564331?i=1000654893564">Triple Your Response Rates Using An "Exit Clause"</a> (May 2024)</li>
+    <li>The Dream Job System (Austin Belcak): <a href="https://podcasts.apple.com/us/podcast/6-linkedin-hacks-that-99-of-job-seekers-dont-know-ep-681/id1542564331?i=1000702825510">6 LinkedIn Hacks That 99% Of Job Seekers Don't Know</a> (Apr 2025)</li>
+    <li>The Dream Job System (Austin Belcak): <a href="https://podcasts.apple.com/us/podcast/how-to-find-anyones-email-address-ep-632/id1542564331?i=1000680524113">How To Find Anyone's Email Address</a> (Dec 2024)</li>
+    <li>The Dream Job System (Austin Belcak): <a href="https://podcasts.apple.com/us/podcast/the-dream-100-formula-for-networking-ep-536/id1542564331?i=1000654640145">The "Dream 100" Formula For Networking</a> (May 2024)</li>
+    <li>The Dream Job System (Austin Belcak): <a href="https://podcasts.apple.com/us/podcast/how-to-get-10-interviews-in-2-weeks-ep-684/id1542564331?i=1000703703431">How To Get 10+ Interviews In 2 Weeks</a> (Apr 2025)</li>
   </ul>
 </div>
 

--- a/playbooks/getting-honest-feedback-at-work.html
+++ b/playbooks/getting-honest-feedback-at-work.html
@@ -873,6 +873,7 @@ footer p { color: var(--muted); font-size: 14px; }
   <h2>More playbooks in this series</h2>
   <p class="cluster-nav-lead">This playbook is part of the <a href="/get-promoted">Get Promoted</a> series. Keep going with the rest:</p>
   <ul>
+    <li><a href="/playbooks/how-to-get-360-feedback">Get 360 feedback</a></li>
     <li><a href="/playbooks/how-to-ask-for-a-promotion">How to ask for a promotion</a></li>
     <li><a href="/playbooks/promotion-denied-questions">Promotion denied? 9 questions to ask</a></li>
     <li><a href="/playbooks/ask-for-raise-after-more-responsibility">Ask for a raise after taking on more</a></li>

--- a/playbooks/how-to-get-360-feedback.html
+++ b/playbooks/how-to-get-360-feedback.html
@@ -1,0 +1,734 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+<meta name="description" content="How to run your own 360: pick a challenge network, ask questions people can actually answer, take the feedback so it keeps coming, and turn one round into a system.">
+<meta name="color-scheme" content="light">
+<title>How to Get 360 Feedback, With or Without the Official Process | Work Coach</title>
+<link rel="canonical" href="https://work.coach/playbooks/how-to-get-360-feedback">
+<script type="application/ld+json">{"@context":"https://schema.org","@type":"Article","headline":"How to Get 360 Feedback, With or Without the Official Process","description":"How to run your own 360: pick a challenge network, ask questions people can actually answer, take the feedback so it keeps coming, and turn one round into a system.","author":{"@type":"Organization","name":"Work Coach"},"mainEntityOfPage":"https://work.coach/playbooks/how-to-get-360-feedback"}</script>
+<link rel="icon" href="../img/favicon.ico">
+<link rel="icon" type="image/png" sizes="32x32" href="../img/favicon-32.png">
+<link rel="icon" type="image/png" sizes="16x16" href="../img/favicon-16.png">
+<link rel="apple-touch-icon" href="../img/apple-touch-icon.png">
+
+<meta property="og:type" content="article">
+<meta property="og:url" content="https://work.coach/playbooks/how-to-get-360-feedback">
+<meta property="og:site_name" content="Work Coach">
+<meta property="og:title" content="How to Get 360 Feedback, With or Without the Official Process">
+<meta property="og:description" content="How to run your own 360: pick a challenge network, ask questions people can actually answer, take the feedback so it keeps coming, and turn one round into a system.">
+<meta property="og:image" content="https://work.coach/img/og-image-whistle.png">
+<meta property="og:image:width" content="1200">
+<meta property="og:image:height" content="630">
+
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="How to Get 360 Feedback, With or Without the Official Process">
+<meta name="twitter:description" content="How to run your own 360: pick a challenge network, ask questions people can actually answer, take the feedback so it keeps coming, and turn one round into a system.">
+<meta name="twitter:image" content="https://work.coach/img/og-image-whistle.png">
+
+<script>
+  !function(t,e){var o,n,p,r;e.__SV||(window.posthog=e,e._i=[],e.init=function(i,s,a){function g(t,e){var o=e.split(".");2==o.length&&(t=t[o[0]],e=o[1]),t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))}}(p=t.createElement("script")).type="text/javascript",p.crossOrigin="anonymous",p.async=!0,p.src=s.api_host.replace(".i.posthog.com","-assets.i.posthog.com")+"/static/array.js",(r=t.getElementsByTagName("script")[0]).parentNode.insertBefore(p,r);var u=e;for(void 0!==a?u=e[a]=[]:a="posthog",u.people=u.people||[],u.toString=function(t){var e="posthog";return"posthog"!==a&&(e+="."+a),t||(e+=" (stub)"),e},u.people.toString=function(){return u.toString(1)+".people (stub)"},o="init capture register register_once register_for_session unregister unregister_for_session getFeatureFlag getFeatureFlagPayload isFeatureEnabled reloadFeatureFlags updateEarlyAccessFeatureEnrollment getEarlyAccessFeatures on onFeatureFlags onSessionId getSurveys getActiveMatchingSurveys renderSurvey canRenderSurvey getNextSurveyStep identify setPersonProperties group resetGroups setPersonPropertiesForFlags resetPersonPropertiesForFlags setGroupPropertiesForFlags resetGroupPropertiesForFlags reset get_distinct_id getGroups get_session_id get_session_replay_url alias set_config startSessionRecording stopSessionRecording sessionRecordingStarted captureException loadToolbar get_property getSessionProperty createPersonProfile opt_in_capturing opt_out_capturing has_opted_in_capturing has_opted_out_capturing clear_opt_in_out_capturing debug".split(" "),n=0;n<o.length;n++)g(u,o[n]);e._i.push([i,s,a])},e.__SV=1)}(document,window.posthog||[]);
+  posthog.init('phc_1qX2rgCW83ghyqnBLTO6ZADUvTvceD36DwDochmrxfB',{api_host:'https://us.i.posthog.com', defaults:'2025-11-30'})
+</script>
+
+<link href="https://fonts.googleapis.com/css2?family=Playfair+Display:ital,wght@0,400;0,600;1,400&family=Source+Sans+3:wght@400;500;600;700&display=swap" rel="stylesheet">
+<style>
+*, *::before, *::after { margin: 0; padding: 0; box-sizing: border-box; }
+
+:root {
+  --bg: #f5f0e8;
+  --surface: #ebe5da;
+  --muted: #6b7a6e;
+  --text: #1a2e22;
+  --card: #fffdf8;
+  --border: #d6d0c4;
+  --accent: #31c178;
+  --accent-2: #1e6b42;
+  --accent-dark: #28a366;
+  --shadow: 0 10px 30px rgba(0,0,0,.07);
+  --radius: 16px;
+  --maxw: 1100px;
+  --green-soft: rgba(49, 193, 120, 0.1);
+}
+
+html { scroll-behavior: smooth; }
+article h2[id] { scroll-margin-top: 96px; }
+body {
+  font-family: 'Source Sans 3', ui-sans-serif, system-ui, -apple-system, sans-serif;
+  background: var(--bg);
+  color: var(--text);
+  line-height: 1.7;
+  -webkit-font-smoothing: antialiased;
+}
+
+/* NAV */
+nav {
+  padding: 24px 0;
+  border-bottom: 1px solid var(--border);
+  position: sticky;
+  top: 0;
+  z-index: 50;
+  backdrop-filter: saturate(120%) blur(10px);
+  background: color-mix(in oklab, var(--bg) 85%, transparent);
+}
+.nav-inner {
+  max-width: var(--maxw);
+  margin: 0 auto;
+  padding: 0 max(20px, env(safe-area-inset-left));
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+.logo {
+  display: flex; align-items: center; gap: 10px;
+  font-weight: 800; text-decoration: none; color: var(--text); font-size: 16px;
+}
+.logo-dot {
+  width: 10px; height: 10px;
+  background: var(--accent);
+  border-radius: 999px;
+  animation: pulse 2.5s ease-in-out infinite;
+}
+@keyframes pulse {
+  0%, 100% { opacity: 1; transform: scale(1); }
+  50% { opacity: 0.4; transform: scale(0.8); }
+}
+.nav-links { display: flex; align-items: center; gap: 28px; }
+.nav-links a {
+  color: var(--muted); text-decoration: none;
+  font-size: 15px; font-weight: 500; transition: color 0.2s;
+}
+.nav-links a:hover { color: var(--text); }
+.btn-primary {
+  display: inline-flex; align-items: center; gap: 8px;
+  padding: 10px 20px;
+  background: var(--accent);
+  color: #ffffff;
+  text-decoration: none;
+  font-size: 14px; font-weight: 700;
+  border-radius: 999px;
+  font-family: 'Source Sans 3', sans-serif;
+  transition: background 0.2s;
+}
+.btn-primary:hover { background: color-mix(in oklab, var(--accent) 85%, white); }
+.btn-lg { padding: 16px 32px; font-size: 15px; }
+@media (max-width: 720px) { .nav-links { display: none; } }
+
+/* ARTICLE */
+.post-hero {
+  max-width: 780px;
+  margin: 0 auto;
+  padding: 72px 20px 12px;
+}
+.post-kicker {
+  font-size: 13px;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  color: var(--accent);
+  margin-bottom: 18px;
+}
+.post-hero h1 {
+  font-family: 'Playfair Display', serif;
+  font-size: clamp(32px, 4.5vw, 48px);
+  font-weight: 400;
+  line-height: 1.15;
+  letter-spacing: -0.012em;
+  margin-bottom: 16px;
+}
+.post-hero .post-sub {
+  font-size: 19px;
+  color: color-mix(in oklab, var(--muted) 86%, white 14%);
+  line-height: 1.5;
+  margin-bottom: 20px;
+}
+.post-meta {
+  font-size: 14px;
+  color: var(--muted);
+  padding-bottom: 28px;
+  border-bottom: 1px solid var(--border);
+}
+article {
+  max-width: 780px;
+  margin: 0 auto;
+  padding: 12px 20px 64px;
+}
+article h2 {
+  font-family: 'Playfair Display', serif;
+  font-size: clamp(24px, 3vw, 32px);
+  font-weight: 400;
+  line-height: 1.25;
+  margin: 44px 0 14px;
+}
+article h3 {
+  font-family: 'Playfair Display', serif;
+  font-size: 21px;
+  font-weight: 600;
+  line-height: 1.3;
+  margin: 32px 0 10px;
+}
+article p { font-size: 17px; margin: 0 0 18px; }
+article ul, article ol { margin: 0 0 18px 24px; font-size: 17px; }
+article li { margin-bottom: 8px; }
+article a { color: var(--accent-2); }
+article strong { font-weight: 700; }
+
+/* Expert nugget card */
+.nugget {
+  background: var(--card);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 24px 26px 20px;
+  margin: 26px 0;
+  box-shadow: var(--shadow);
+  overflow: hidden;
+}
+.nugget::before {
+  content: "";
+  display: block;
+  height: 3px;
+  background: linear-gradient(90deg, var(--accent), var(--accent-2));
+  margin: -24px -26px 20px;
+}
+.nugget blockquote {
+  font-family: 'Playfair Display', serif;
+  font-size: 18.5px;
+  font-style: italic;
+  line-height: 1.5;
+  margin-bottom: 12px;
+}
+.nugget .nugget-who {
+  font-size: 14px;
+  color: var(--muted);
+  margin-bottom: 10px;
+}
+.nugget .nugget-who strong { color: var(--text); }
+.nugget .nugget-watch {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 14px;
+  font-weight: 700;
+  color: var(--accent-2);
+  text-decoration: none;
+}
+.nugget .nugget-watch:hover { text-decoration: underline; }
+.nugget .video-embed { margin: 18px 0 4px; box-shadow: none; }
+.nugget-lead { font-size: 15px; color: var(--muted); margin-bottom: 14px; line-height: 1.55; }
+.nugget-lead strong { color: var(--text); }
+.video-lead { font-size: 15px; color: var(--muted); margin: 26px 0 10px; line-height: 1.55; }
+.video-lead strong { color: var(--text); }
+.video-lead + .video-embed { margin-top: 0; margin-bottom: 26px; }
+.audio-embed iframe {
+  width: 100%;
+  height: 175px;
+  border: 0;
+  border-radius: 12px;
+}
+
+/* Watch/Listen toggle for sources with both video and audio */
+.media-tabs { display: flex; gap: 8px; margin-bottom: 14px; }
+.media-tab {
+  border: 1px solid var(--border);
+  background: transparent;
+  color: var(--muted);
+  font-family: inherit;
+  font-size: 13.5px;
+  font-weight: 700;
+  padding: 7px 14px;
+  border-radius: 999px;
+  cursor: pointer;
+  transition: color 0.15s, border-color 0.15s, background 0.15s;
+}
+.media-tab:hover { color: var(--text); }
+.media-tab.active { background: var(--green-soft); border-color: var(--accent-dark); color: var(--accent-2); }
+.media-pane .video-embed { margin: 0; }
+.media-pane .audio-embed { margin: 0; }
+
+/* LAYOUT WITH FLOATING TOC */
+.layout {
+  max-width: var(--maxw);
+  margin: 0 auto;
+  padding: 12px 20px 64px;
+  display: grid;
+  grid-template-columns: minmax(0, 780px) 240px;
+  gap: 56px;
+  align-items: start;
+  justify-content: center;
+}
+.layout article { max-width: none; margin: 0; padding: 0; }
+.toc {
+  position: sticky;
+  top: 105px;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 22px;
+}
+.toc strong { display: block; margin-bottom: 12px; font-size: 15px; }
+.toc a {
+  display: block;
+  text-decoration: none;
+  color: var(--muted);
+  font-size: 14px;
+  line-height: 1.4;
+  padding: 7px 0;
+  transition: color 0.15s;
+}
+.toc a:hover { color: var(--text); }
+.toc a.active { color: var(--accent-2); font-weight: 700; }
+@media (max-width: 900px) {
+  .layout { grid-template-columns: 1fr; }
+  .toc { display: none; }
+}
+
+/* YouTube embed */
+.video-embed {
+  position: relative;
+  width: 100%;
+  aspect-ratio: 16 / 9;
+  border-radius: 12px;
+  overflow: hidden;
+  border: 1px solid var(--border);
+  box-shadow: var(--shadow);
+  margin: 26px 0 8px;
+  background: #000;
+}
+.video-embed iframe {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  border: 0;
+}
+.video-caption {
+  font-size: 13.5px;
+  color: var(--muted);
+  margin-bottom: 26px;
+}
+
+/* Callout / template box */
+.callout {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 22px 24px;
+  margin: 26px 0;
+}
+.callout h4 {
+  font-size: 13px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--accent-2);
+  margin-bottom: 10px;
+}
+.callout p, .callout li { font-size: 16px; }
+.callout ul, .callout ol { margin-left: 22px; }
+
+/* Mid-article CTA */
+.cta-band {
+  background: var(--card);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 30px 32px;
+  margin: 40px 0;
+  text-align: center;
+  box-shadow: var(--shadow);
+}
+.cta-band h3 {
+  font-family: 'Playfair Display', serif;
+  font-size: 24px;
+  font-weight: 400;
+  margin: 0 0 8px;
+}
+.cta-band p { font-size: 15.5px; color: var(--muted); margin-bottom: 18px; }
+.cta-band .fine-print { font-size: 13px; color: var(--muted); opacity: 0.6; margin: 10px 0 0; }
+
+/* Sources */
+.sources {
+  border-top: 1px solid var(--border);
+  margin-top: 48px;
+  padding-top: 24px;
+}
+.sources h2 { margin-top: 0; }
+.sources li { font-size: 15.5px; color: var(--muted); }
+
+
+/* Cluster nav */
+.cluster-nav {
+  background: var(--card);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 28px 30px 26px;
+  margin-top: 48px;
+  box-shadow: var(--shadow);
+}
+.cluster-nav h2 { margin: 0 0 6px; font-size: 24px; }
+.cluster-nav .cluster-nav-lead { font-size: 15.5px; color: var(--muted); margin-bottom: 16px; }
+.cluster-nav ul {
+  list-style: none;
+  margin: 0;
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 8px 28px;
+}
+.cluster-nav li { margin: 0; font-size: 15.5px; }
+.cluster-nav ul a { font-weight: 600; color: var(--accent-2); text-decoration: none; }
+.cluster-nav ul a:hover { text-decoration: underline; }
+@media (max-width: 560px) { .cluster-nav ul { grid-template-columns: 1fr; } }
+
+/* FOOTER */
+footer {
+  padding: 32px 0;
+  background: var(--bg);
+  border-top: 1px solid var(--border);
+}
+.footer-inner {
+  max-width: var(--maxw);
+  margin: 0 auto;
+  padding: 0 20px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 16px;
+}
+footer p { color: var(--muted); font-size: 14px; }
+.footer-links { display: flex; gap: 24px; }
+.footer-links a { color: var(--muted); text-decoration: none; font-size: 14px; transition: color 0.2s; }
+.footer-links a:hover { color: var(--text); }
+</style>
+</head>
+<body>
+
+<nav>
+  <div class="nav-inner">
+    <a href="/" class="logo"><span class="logo-dot"></span> Work Coach</a>
+    <div class="nav-links">
+      <a href="/#how">How it works</a>
+      <a href="/#features">What you get</a>
+      <a href="/#pricing">Pricing</a>
+      <a href="/#faq">FAQ</a>
+      <a href="/playbooks/">Playbooks</a>
+    </div>
+    <a href="https://my.work.coach" class="btn-primary">Start Free Trial</a>
+  </div>
+</nav>
+
+<div class="post-hero">
+  <div class="post-kicker">Career Growth</div>
+  <h1>How to get 360 feedback, with or without the official process</h1>
+  <p class="post-sub">Kim Scott, a retired Amazon VP, Netflix's CTO, and Zapier's CEO on collecting the feedback your annual review won't give you: who to ask, what to ask, and how to take it so people keep telling you the truth.</p>
+  <div class="post-meta">14 min read</div>
+</div>
+
+<main class="layout">
+<article>
+<p>A 360 is just feedback from every side of your work: your manager, your peers, the people who report to you, and the partners on other teams who see a version of you that none of the others do. Companies run formal versions once or twice a year. You don't need one to get the benefits, and if you wait for one, most of what you learn will arrive months after you could have used it.</p>
+
+<p>This playbook covers how to run the informal version yourself: choosing the reviewers, asking questions people can actually answer, receiving the answers so a second round happens, and turning one round into a rhythm. It also covers how to work the official process when your company has one, and where 360s go wrong. If the problem is getting even one person to tell you the truth, start with the <a href="/playbooks/getting-honest-feedback-at-work">honest feedback playbook</a>; this one is about assembling the full picture from many people at once.</p>
+
+<p>The advice comes from people who have run this at every altitude, from Kim Scott, who wrote Radical Candor, to executives at Amazon, Netflix, Zapier, and Bridgewater. Every quote plays at the moment it was said.</p>
+
+<h2 id="why-you-can-t-wait-for-the-official-cycle">Why you can't wait for the official cycle</h2>
+
+<p>The annual review is the worst place to hear about a problem for the first time. It's attached to pay and promotion, so everyone involved is careful, and it batches a year of observations into one document. Ethan Evans's blunt version: if the first time you hear about a weakness is in the review that sets your raise, you've already paid for it.</p>
+
+<p>Even the best-run cycles deliver their news late. Elizabeth Stone gets about 300 pieces of feedback in Netflix's annual 360, and some of them describe things that happened six months earlier. "I think, oh, I wish you had told me this at the time."</p>
+
+<p>The weaker versions have a different problem: the tool teaches people to soften. Liz Christo, a general partner at Stage 2 Capital, watched formal 360s come back "kind of nice" while the real conversation happened somewhere else, and the anonymity rarely survived contact: "we all know who it's from" (<a href="https://podcasts.apple.com/us/podcast/i-had-to-dramatically-change-my-working-style-ft-liz/id1676766133?i=1000654057110&t=2068">34:28 in her Delivering Value episode</a>).</p>
+
+<p>So the version you run yourself is not a substitute for the official one. It's the thing the official one is a periodic approximation of.</p>
+
+<h2 id="pick-a-challenge-network-not-a-fan-club">Pick a challenge network, not a fan club</h2>
+
+<p>The instinct when choosing who to ask is to pick people who like you. Adam Grant's research points the other way: left alone, we quietly drop our critics and surround ourselves with cheerleaders, which is exactly how blind spots survive. His fix is what he calls a challenge network: "the group of people that you trust to push you to get better. They tell you the stuff you don't want to hear, but need to hear" (<a href="https://podcasts.apple.com/us/podcast/worklife-with-adam-grant-how-to-love-criticism/id1346314086?i=1000404159792&t=731">12:11 in the WorkLife episode</a>).</p>
+
+<p>For a working 360, seven to ten people covers every side without becoming a survey program:</p>
+
+<div class="callout">
+  <h4>The reviewer list</h4>
+  <ul>
+    <li><strong>Your manager</strong>, who sees your output and how it lands above you.</li>
+    <li><strong>Your manager's manager.</strong> A skip-level sees your scope and your trajectory rather than your day-to-day, and their read on how you're perceived above the line is data nobody else on this list has. If you already run <a href="/playbooks/skip-level-meeting-with-bosses-boss">skip-level meetings</a>, this is one question added to the next one.</li>
+    <li><strong>Three or more peers</strong>, at least one of whom has pushed back on you before. That's your challenge network seat.</li>
+    <li><strong>Your reports, if you have them.</strong> They hold the data nobody above you can see, and skipping them is how managers stay surprised.</li>
+    <li><strong>One or two cross-functional partners</strong>, the people who experience you as a dependency rather than a teammate.</li>
+  </ul>
+  <p>Ask people close enough to your work to have real observations. Evans warns against sending requests to distant colleagues: they decline, and in tools where declines are visible, a trail of declines reads worse than a short list. And if any group will answer anonymously, it needs at least three people to actually be anonymous, which is what sets the minimum sizes above.</p>
+</div>
+
+<h2 id="give-people-permission-before-you-ask">Give people permission before you ask</h2>
+
+<p>Nobody owes you candor, and most people have learned that giving it is risky. The person who tells you the truth pays a social cost if you flinch, so their rational default is "everything's fine." That means the first move isn't a question, it's permission.</p>
+
+<div class="nugget">
+  <p class="nugget-lead"><strong>Permission first.</strong> The player below is queued to 8:29, the exact moment Ethan Evans says it. <a href="https://www.youtube.com/watch?v=ISQUwDiTmDo&t=509s">Watch on YouTube</a>.</p>
+  <blockquote>"First, if you want to get honest feedback from somebody you need to give them permission."</blockquote>
+  <div class="nugget-who"><strong>Ethan Evans</strong>, retired Amazon VP · Level Up</div>
+  <div class="video-embed">
+  <iframe src="https://www.youtube-nocookie.com/embed/ISQUwDiTmDo?start=509" title="Ethan Evans at 8:29" loading="lazy" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+  </div>
+</div>
+
+<p>Permission sounds like naming the risk out loud: "I'm working on how I run meetings, and I'd genuinely rather hear it from you than keep guessing. Trust me, I'm open to it." Say why you're asking, say what you'll do with it, and mean the last part, because the second round depends entirely on what you did with the first. Our <a href="/playbooks/getting-honest-feedback-at-work">honest feedback playbook</a> covers why the people around you softened in the first place; this is the antidote applied deliberately.</p>
+
+<h2 id="ask-a-question-someone-can-actually-answer">Ask a question someone can actually answer</h2>
+
+<p>The question most people ask is the one guaranteed to fail. Kim Scott has watched it fail for years:</p>
+
+<div class="nugget">
+  <p class="nugget-lead"><strong>The question that wastes your breath.</strong> The player below is queued to 37:49, the exact moment Kim Scott says it. <a href="https://www.youtube.com/watch?v=V7tnbx-6Ayc&t=2269s">Watch on YouTube</a>.</p>
+  <blockquote>"So if you say, do you have any feedback for me? You're wasting your breath. The other person's going to say, oh no, everything's fine."</blockquote>
+  <div class="nugget-who"><strong>Kim Scott</strong>, author of Radical Candor · Lenny's Podcast</div>
+  <div class="video-embed">
+  <iframe src="https://www.youtube-nocookie.com/embed/V7tnbx-6Ayc?start=2269" title="Kim Scott at 37:49" loading="lazy" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+  </div>
+</div>
+
+<p>Her replacement is a go-to question you write once and keep: hers is "What could I do or stop doing that would make it easier to work with me?" The wording is doing real work there. It assumes something exists, it's scoped to working with you rather than judging you, and it can't be answered with "fine." But she's emphatic that you shouldn't borrow her sentence, because a script in someone else's voice reads as a script: "there's no such thing as emotional novocaine." Write one that sounds like you.</p>
+
+<div class="callout">
+  <h4>Go-to questions that have worked</h4>
+  <ul>
+    <li><strong>Kim Scott:</strong> "What could I do or stop doing that would make it easier to work with me?"</li>
+    <li><strong>Christa Quarles, CEO of OpenTable:</strong> "Tell me why I'm wrong."</li>
+    <li><strong>Jason Rosoff, CEO of Radical Candor:</strong> "What could I have done this week to better support you?"</li>
+    <li><strong>Lenny Rachitsky:</strong> "What's one way I could help you be more successful?"</li>
+    <li><strong>The positive half, from Ethan Evans:</strong> "What am I doing well that I could double down on?"</li>
+  </ul>
+</div>
+
+<p>Wade Foster runs Zapier's formal 360s twice a year, and his personal technique for getting useful answers is to stop asking about himself entirely:</p>
+
+<div class="nugget">
+  <p class="nugget-lead"><strong>Ask about the project, not the performance.</strong> The player below is queued to 9:40, the exact moment Wade Foster says it. <a href="https://www.youtube.com/watch?v=Nkx2yJP2op8&t=580s">Watch on YouTube</a>.</p>
+  <blockquote>"To get better feedback, I usually try not to ask feedback for my performance. How do you think I'm doing on the job? No one has feedback about that."</blockquote>
+  <div class="nugget-who"><strong>Wade Foster</strong>, CEO of Zapier · Mochary Method</div>
+  <div class="video-embed">
+  <iframe src="https://www.youtube-nocookie.com/embed/Nkx2yJP2op8?start=580" title="Wade Foster at 9:40" loading="lazy" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+  </div>
+</div>
+
+<p>His version anchors to a shared artifact instead: "How could we have done twice as well on this project?" The answers are about the work, but you own the work, so the feedback is about you without anyone having to say so. It's the easiest question on this page for a nervous colleague to answer honestly.</p>
+
+<p>Jules Walter, a product leader at YouTube, adds the version for when the power gap runs the other way, when people see giving you feedback as a risk they didn't sign up for:</p>
+
+<div class="nugget">
+  <p class="nugget-lead"><strong>Make it safe to say.</strong> The player below is queued to 46:12, the exact moment Jules Walter says it. <a href="https://www.youtube.com/watch?v=zn2JNbZwf00&t=2772s">Watch on YouTube</a>.</p>
+  <blockquote>"So I basically learned to go out of my way and make people comfortable giving me feedback."</blockquote>
+  <div class="nugget-who"><strong>Jules Walter</strong>, product leader at YouTube · Lenny's Podcast</div>
+  <div class="video-embed">
+  <iframe src="https://www.youtube-nocookie.com/embed/zn2JNbZwf00?start=2772" title="Jules Walter at 46:12" loading="lazy" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+  </div>
+</div>
+
+<p>Two of his techniques travel well. Ask about one named dimension you're already working on, "to what extent did I show executive presence in that meeting?", so the other person is confirming or adjusting rather than initiating. Or criticize yourself first and let them calibrate: "I thought I lost the room in the second half, does that match what you saw?" Agreeing with you costs them almost nothing, and disagreeing with you is, technically, a compliment.</p>
+
+<div class="cta-band">
+  <h3>The feedback nobody has to write</h3>
+  <p>A 360 asks busy people to remember how you show up. Work Coach watches the meetings themselves and surfaces what a candid colleague would point out, every week — <a href="/360-feedback">continuous evidence to read your reviewers' answers against</a>.</p>
+  <a href="https://my.work.coach" class="btn-primary btn-lg">Start Free Trial</a>
+  <p class="fine-print">2-week trial, no credit card needed. Your data is never shared with your employer.</p>
+</div>
+
+<h2 id="take-it-so-the-second-round-happens">Take it so the second round happens</h2>
+
+<p>Everything before this point buys you one honest answer. Whether you ever get a second one depends on the thirty seconds after you hear the first.</p>
+
+<p>Kim Scott's mechanical trick for those thirty seconds: "the simplest way to embrace the discomfort is to close your mouth and count to six." Six seconds of silence feels endless, and it's usually where the real sentence arrives, because the speaker fills it with the thing they softened the first time. Ethan Evans supplies the only acceptable opening reply: "The correct answer to all feedback is thank you. Now, you can say more than thank you, but you don't argue." Then ask for a concrete example, and if they can't produce one, make the ask that turns one conversation into a standing arrangement: "the next time you see it, could you point it out in the moment?"</p>
+
+<p>Ray Dalio got a written D-minus from an employee for a rambling meeting, and his response, asking every attendee to grade him and sharing the results with the company, is extreme. The idea underneath it isn't:</p>
+
+<div class="nugget">
+  <p class="nugget-lead"><strong>The second score.</strong> This one is audio only. The quote is at 33:19; the player starts from the top, or <a href="https://podcasts.apple.com/us/podcast/worklife-with-adam-grant-how-to-love-criticism/id1346314086?i=1000404159792&t=1999">open it on Apple Podcasts cued to 33:19</a>.</p>
+  <blockquote>"I can control the second score, which is how well did I take the first score? And so even if I got a D-minus for my performance, I can get an A-plus for how I took the feedback."</blockquote>
+  <div class="nugget-who"><strong>Ray Dalio</strong>, founder of Bridgewater · WorkLife with Adam Grant</div>
+  <div class="audio-embed">
+    <iframe src="https://embed.podcasts.apple.com/us/podcast/worklife-with-adam-grant-how-to-love-criticism/id1346314086?i=1000404159792&theme=auto" height="175" frameborder="0" sandbox="allow-forms allow-popups allow-same-origin allow-scripts allow-top-navigation-by-user-activation" allow="autoplay *; encrypted-media *; clipboard-write" loading="lazy" title="WorkLife with Adam Grant: How to Love Criticism - Apple Podcasts"></iframe>
+  </div>
+</div>
+
+<p>You can't control the grade. You fully control how you take it, and the people watching you take it are deciding whether to ever grade you honestly again. Mellody Hobson, co-CEO of Ariel Investments, held back tears through brutal feedback from Bill Bradley for exactly this reason: "if I cry, he won't ever give me feedback again" (<a href="https://podcasts.apple.com/us/podcast/rethinking-mellody-hobson-on-taking-tough-feedback/id1346314086?i=1000525532675&t=483">7:56 in her WorkLife episode</a>). Her coach's repetition rule is also worth carrying into any 360 read-out: one person's comment is a data point, but "the third time they call you a horse's ass, buy a saddle."</p>
+
+<p>One logistical rule from Matt Mochary's coaching curriculum: never take serious feedback over Slack or email, and budget twenty to thirty minutes when you receive it live. Hard words in text hit the threat response with no tone and no repair loop, and his observation is that within a day or two, confirmation bias starts doing permanent damage that a live conversation would have resolved in minutes (<a href="https://www.youtube.com/watch?v=JLkYgUnnbU8">Mochary Method Class 2</a>).</p>
+
+<h2 id="close-the-loop-then-make-it-a-rhythm">Close the loop, then make it a rhythm</h2>
+
+<p>Feedback you visibly acted on is the only advertisement that gets you more. Report back to each person: what you heard, what you changed, and what you'd like them to watch for next. Then ask the follow-up that proves you meant it, Scott's favorite: "Did I overcorrect?"</p>
+
+<p>For cadence, Scott's floor for managers is startlingly high: solicit feedback "every week, from each of your direct reports," which in practice means budgeting the last five minutes of every 1:1 and asking your go-to question until answering it stops being scary. For everyone else, the same question aimed at a peer or your boss once every few weeks keeps the channel open at nearly zero cost.</p>
+
+<p>And when something real needs to change, make the loop measurable. After Samantha Leal, a growth leader, learned secondhand that her team was afraid of her, she convened the whole team, apologized, asked for specifics, wrote every item on the board, and committed to a follow-up meeting a month out. Then she added the step that turned an apology into a system:</p>
+
+<div class="nugget">
+  <p class="nugget-lead"><strong>Put a number on the change.</strong> This one is audio only. The quote is at 29:00; the player starts from the top, or <a href="https://podcasts.apple.com/us/podcast/i-decided-to-hold-a-no-holds-barred-feedback/id1676766133?i=1000659403405&t=1740">open it on Apple Podcasts cued to 29:00</a>.</p>
+  <blockquote>"And I asked them to score me from zero to 10 so that I know whether I'm improving or not."</blockquote>
+  <div class="nugget-who"><strong>Samantha Leal</strong>, growth leader and advisor · Delivering Value</div>
+  <div class="audio-embed">
+    <iframe src="https://embed.podcasts.apple.com/us/podcast/i-decided-to-hold-a-no-holds-barred-feedback/id1676766133?i=1000659403405&theme=auto" height="175" frameborder="0" sandbox="allow-forms allow-popups allow-same-origin allow-scripts allow-top-navigation-by-user-activation" allow="autoplay *; encrypted-media *; clipboard-write" loading="lazy" title="Delivering Value: No-Holds-Barred Feedback Session with Samantha Leal - Apple Podcasts"></iframe>
+  </div>
+</div>
+
+<p>The scores took three or four months to move. That's the honest timescale for a reputation changing, and the monthly number is what kept both sides from giving up in month two. Team members thanked her privately; she calls the whole episode career-defining.</p>
+
+<h2 id="pick-the-channel-conversations-a-form-or-a-tool">Pick the channel: conversations, a form, or a tool</h2>
+
+<p>Two decisions here: which channel carries which conversations, and who stays anonymous. The everyday conversations are named by nature; anonymity is a property of the deliberate written round, and there it follows a working convention. Feedback from people above you, your manager and your skip-level, is unmasked, because they're paid to tell you directly and there's no way to anonymize a bucket of one. Feedback from your level and below, peers, reports, and the people you influence without authority, goes anonymous, because that's the direction where candor carries real risk. The mechanics follow from the convention.</p>
+
+<p><strong>Conversations</strong> carry the unmasked tier and the continuous rhythm. Your go-to question in 1:1s, the skip-level ask, the project debrief with a peer who'll say it to your face: named, live, and the only channel where the follow-up question works. Everything earlier on this page is this channel.</p>
+
+<p><strong>A quick anonymous form</strong> carries the lateral-and-below tier for the deliberate once-or-twice-a-year round. A Google Form set to collect no email addresses is genuinely enough: your go-to question as an open text box, a "what should I keep doing?" box, and one 0-to-10 score you can track between rounds, the way Samantha Leal did. Keep it under five questions so people finish it. The three-person rule is what keeps the promise honest: if a bucket has fewer than three respondents, merge it into the next one or drop the segmentation, because "anonymous" feedback from a bucket of two is a guessing game you've invited people into.</p>
+
+<p><strong>Tools</strong> take over when you want the round to run without you administering it. If your company already pays for an engagement platform, it can usually run a personal 360; Zapier runs its formal cycle on Culture Amp twice a year. And <a href="/360-feedback">Work Coach's 360 feedback</a> covers the layer none of these channels can: it observes your actual meetings and surfaces what a candid colleague would point out, continuously. It isn't your colleagues' own words, but it's the evidence to read them against, it never goes stale, and it needs no anonymity plan.</p>
+
+<h2 id="if-your-company-runs-a-formal-360">If your company runs a formal 360</h2>
+
+<p>Work the official process instead of just submitting to it. Evans's advice from the inside: if you've changed teams or managers recently, your record is thin, so prompt your current and former managers and the peers who actually saw your work to submit input. A 360 populated by the right eight people is a different document from one populated by whoever the tool guessed.</p>
+
+<p>At the receiving end, compress before you react. Elizabeth Stone's method for her 300 pieces:</p>
+
+<div class="nugget">
+  <p class="nugget-lead"><strong>Distill themes, then bring them to your manager.</strong> The player below is queued to 34:43, the exact moment Elizabeth Stone says it. <a href="https://www.youtube.com/watch?v=2XgU6T4DalY&t=2083s">Watch on YouTube</a>.</p>
+  <blockquote>"We do have an annual cycle of 360 feedback, where you request and receive feedback from a lot of people. But it's not an input to some output."</blockquote>
+  <div class="nugget-who"><strong>Elizabeth Stone</strong>, CTO of Netflix · Lenny's Podcast</div>
+  <div class="video-embed">
+  <iframe src="https://www.youtube-nocookie.com/embed/2XgU6T4DalY?start=2083" title="Elizabeth Stone at 34:43" loading="lazy" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+  </div>
+</div>
+
+<p>She distills the themes and proactively tees them up with her manager, which turns the pile into two or three workstreams and signals exactly the second score Dalio was talking about. Netflix deliberately decouples the cycle from compensation so people write the truth; if yours is attached to comp, read it knowing everyone was careful.</p>
+
+<p>One caution on the themes themselves: interrogate them before adopting them. The executive coach Donna Lichaw tells the story of a client whose 360s kept praising her "attention to detail," a label she hated and that kept earning her more detail work (<a href="https://podcasts.apple.com/us/podcast/how-to-discover-your-superpowers-own-your-story-and/id1627920305?i=1000646757352&t=2798">46:38 on Lenny's Podcast</a>). A repeated theme is real signal, but it describes what people have seen you do, not what you should do more of. Sometimes the right response to a theme is to change the work, not to lean in.</p>
+
+<h2 id="the-asks-on-one-page">The asks on one page</h2>
+
+<div class="callout">
+  <h4>Copy these</h4>
+  <ul>
+    <li><strong>Permission:</strong> "I'm working on X and I'd rather hear it from you than keep guessing. Trust me, I'm open to it."</li>
+    <li><strong>The go-to question (write your own version):</strong> "What could I do or stop doing that would make it easier to work with me?"</li>
+    <li><strong>Project-anchored:</strong> "How could we have done twice as well on this project?"</li>
+    <li><strong>Dimension-specific:</strong> "To what extent did I show [the thing you're working on] in that meeting?"</li>
+    <li><strong>Self-critique first:</strong> "I thought I lost the room in the second half. Does that match what you saw?"</li>
+    <li><strong>When they blank:</strong> "Nothing's ever zero. Would you notice for next time and tell me then?"</li>
+    <li><strong>On receiving:</strong> "Thank you." Then: "Can you give me an example?" Then: "Next time you see it, would you point it out in the moment?"</li>
+    <li><strong>Closing the loop:</strong> "You told me X. Here's what I changed. Did I overcorrect?"</li>
+  </ul>
+</div>
+
+<h2 id="frequently-asked-questions">Frequently asked questions</h2>
+
+<h3>How many people should I ask?</h3>
+<p>Seven to ten: your manager and your skip-level, three or more peers including one critic, your reports if you have them, and one or two cross-functional partners. The floor is set by anonymity, at least three people in any bucket that answers anonymously, and the ceiling by follow-through: more reviewers than you can close the loop with is a survey, not a 360.</p>
+
+<h3>Should the feedback be anonymous?</h3>
+<p>Only in the written round, and only below the line. Your everyday conversations stay named, and feedback from your manager and skip-level comes to your face in any channel, since a bucket of one can't be anonymized anyway. In the written round, peers and reports answer anonymously, with at least three people per bucket so the promise is real. Just don't let anonymity become the whole system: the anonymous form finds the theme, and the named conversation is where the follow-up question turns the theme into something you can act on.</p>
+
+<h3>How often should I run this?</h3>
+<p>Two rhythms. Continuous and small: the go-to question in 1:1s, weekly with reports, every few weeks with everyone else. Deliberate and deeper: the full seven-to-ten-person round once or twice a year, ideally offset from the official cycle so you hear things while they're still fixable.</p>
+
+<h3>What if my manager never gives me anything?</h3>
+<p>Bring the structure to them. Christian Idiodi of SVPG suggests handing your leader the frame: "You are the closest person to me. You see things I will not see. Where do you think I can get better, and if you had to come up with a plan for it, what would it look like?" Then reward whatever comes back, "I got tremendous value from your feedback", because a manager's first attempt at candor is as fragile as anyone else's.</p>
+
+<h3>Do I share what I heard?</h3>
+<p>Share the themes and what you're doing about them, at minimum with the people who contributed. You don't need Dalio-grade transparency, but a one-paragraph "here's what I heard and what I'm changing" note is the strongest possible signal that talking to you was worth it.</p>
+
+<div class="sources">
+  <h2 id="sources">Sources</h2>
+  <ul>
+    <li>Lenny's Podcast: <a href="https://www.youtube.com/watch?v=V7tnbx-6Ayc">Radical Candor: From theory to practice, with Kim Scott</a> (Dec 2023)</li>
+    <li>Level Up (Ethan Evans): <a href="https://www.youtube.com/watch?v=ISQUwDiTmDo">Maximizing Your Performance Review and Goal Setting</a> (May 2023)</li>
+    <li>WorkLife with Adam Grant: <a href="https://podcasts.apple.com/us/podcast/worklife-with-adam-grant-how-to-love-criticism/id1346314086?i=1000404159792">How to Love Criticism, with Ray Dalio</a> (Feb 2018)</li>
+    <li>Mochary Method: <a href="https://www.youtube.com/watch?v=Nkx2yJP2op8">CEO of Zapier: What most people get wrong about feedback, with Wade Foster</a> (Sep 2020)</li>
+    <li>Mochary Method: <a href="https://www.youtube.com/watch?v=JLkYgUnnbU8">How to deliver feedback and onboard new hires, Class 2</a> (Oct 2021)</li>
+    <li>Lenny's Podcast: <a href="https://www.youtube.com/watch?v=zn2JNbZwf00">Leveraging mentors to uplevel your career, with Jules Walter</a> (Jan 2023)</li>
+    <li>Lenny's Podcast: <a href="https://www.youtube.com/watch?v=2XgU6T4DalY">How Netflix builds a culture of excellence, with Elizabeth Stone</a> (Feb 2024)</li>
+    <li>Delivering Value: <a href="https://podcasts.apple.com/us/podcast/i-decided-to-hold-a-no-holds-barred-feedback/id1676766133?i=1000659403405">I Decided to Hold a No-Holds-Barred Feedback Session with my Team, with Samantha Leal</a> (Jun 2024)</li>
+    <li>Delivering Value: <a href="https://podcasts.apple.com/us/podcast/i-had-to-dramatically-change-my-working-style-ft-liz/id1676766133?i=1000654057110">I Had to Dramatically Change My Working Style, with Liz Christo</a> (Apr 2024)</li>
+    <li>WorkLife with Adam Grant: <a href="https://podcasts.apple.com/us/podcast/rethinking-mellody-hobson-on-taking-tough-feedback/id1346314086?i=1000525532675">Mellody Hobson on Taking Tough Feedback</a> (Jun 2021)</li>
+    <li>Product Therapy: <a href="https://podcasts.apple.com/us/podcast/coaching-up/id1738373011?i=1000724973673">Coaching Up, with Christian Idiodi and Leah Hickman</a> (Sep 2025)</li>
+    <li>Lenny's Podcast: <a href="https://podcasts.apple.com/us/podcast/how-to-discover-your-superpowers-own-your-story-and/id1627920305?i=1000646757352">How to discover your superpowers, with Donna Lichaw</a> (Feb 2024)</li>
+  </ul>
+</div>
+
+<div class="cluster-nav">
+  <h2>More playbooks in this series</h2>
+  <p class="cluster-nav-lead">This playbook is part of the <a href="/get-promoted">Get Promoted</a> series. Keep going with the rest:</p>
+  <ul>
+    <li><a href="/playbooks/getting-honest-feedback-at-work">Get honest feedback at work</a></li>
+    <li><a href="/playbooks/how-to-ask-for-a-promotion">Ask for a promotion</a></li>
+    <li><a href="/playbooks/promotion-denied-questions">Promotion denied? 9 questions to ask</a></li>
+    <li><a href="/playbooks/ask-for-raise-after-more-responsibility">Ask for a raise after taking on more</a></li>
+    <li><a href="/playbooks/take-ownership-of-your-career">Take ownership of your career</a></li>
+    <li><a href="/playbooks/respond-to-performance-improvement-plan">Respond to a performance improvement plan</a></li>
+    <li><a href="/playbooks/skip-level-meeting-with-bosses-boss">Skip-level meetings with your boss's boss</a></li>
+  </ul>
+</div>
+</article>
+<aside class="toc">
+  <strong>In this playbook</strong>
+  <a href="#why-you-can-t-wait-for-the-official-cycle">Why you can't wait for the official cycle</a>
+  <a href="#pick-a-challenge-network-not-a-fan-club">Pick a challenge network, not a fan club</a>
+  <a href="#give-people-permission-before-you-ask">Give people permission before you ask</a>
+  <a href="#ask-a-question-someone-can-actually-answer">Ask a question someone can actually answer</a>
+  <a href="#take-it-so-the-second-round-happens">Take it so the second round happens</a>
+  <a href="#close-the-loop-then-make-it-a-rhythm">Close the loop, then make it a rhythm</a>
+  <a href="#pick-the-channel-conversations-a-form-or-a-tool">Pick the channel: conversations, a form, or a tool</a>
+  <a href="#if-your-company-runs-a-formal-360">If your company runs a formal 360</a>
+  <a href="#the-asks-on-one-page">The asks on one page</a>
+  <a href="#frequently-asked-questions">Frequently asked questions</a>
+  <a href="#sources">Sources</a>
+</aside>
+</main>
+
+<script>
+document.querySelectorAll('.media-tabs').forEach(function (tabs) {
+  tabs.addEventListener('click', function (e) {
+    var btn = e.target.closest('.media-tab');
+    if (!btn) return;
+    var card = tabs.parentElement;
+    tabs.querySelectorAll('.media-tab').forEach(function (b) { b.classList.toggle('active', b === btn); });
+    card.querySelectorAll('.media-pane').forEach(function (p) {
+      var show = p.getAttribute('data-pane') === btn.getAttribute('data-target');
+      p.hidden = !show;
+      if (show) {
+        var f = p.querySelector('iframe[data-src]');
+        if (f) { f.src = f.getAttribute('data-src'); f.removeAttribute('data-src'); }
+      }
+    });
+  });
+});
+
+(function () {
+  var links = document.querySelectorAll('.toc a[href^="#"]');
+  if (!links.length || !('IntersectionObserver' in window)) return;
+  var map = {};
+  links.forEach(function (a) { map[a.getAttribute('href').slice(1)] = a; });
+  var current = null;
+  var obs = new IntersectionObserver(function (entries) {
+    entries.forEach(function (e) {
+      if (e.isIntersecting) {
+        if (current) current.classList.remove('active');
+        current = map[e.target.id];
+        if (current) current.classList.add('active');
+      }
+    });
+  }, { rootMargin: '-20% 0px -70% 0px' });
+  document.querySelectorAll('article h2[id]').forEach(function (h) { obs.observe(h); });
+})();
+</script>
+
+<footer>
+  <div class="footer-inner">
+    <p>Your data is never shared with your employer.</p>
+    <div class="footer-links">
+      <a href="/privacy">Privacy</a>
+      <a href="/support">Support</a>
+      <a href="/#faq">FAQ</a>
+    </div>
+  </div>
+</footer>
+
+</body>
+</html>

--- a/playbooks/how-to-tailor-your-resume.html
+++ b/playbooks/how-to-tailor-your-resume.html
@@ -480,6 +480,13 @@ footer p { color: var(--muted); font-size: 14px; }
 
 <p>Second, read it for vocabulary. Recruiters search and skim using the words in their own posting, so if they say "growth marketing" and your resume says "demand generation" for the same work, use their term. This is the honest version of keyword matching: the same facts, described in their words. It helps with screening software too, but the bigger audience is the humans skimming.</p>
 
+<p>There's a risk in taking that vocabulary from a single posting: you end up overfitting to one recruiter's word choices. Austin Belcak, who coaches job seekers at Cultivated Culture, fixes this by extracting keywords from a stack of postings instead. Collect 10 to 20 postings for the same target role, they don't all need to be jobs you'd take, paste them into one document, and count which hard and soft skills keep recurring. The top handful are the vocabulary of the role rather than of one company, and they belong in your bullets, your summary, and your skills section.</p>
+
+<div class="callout">
+  <h4>Where Most Resumes Fall Short</h4>
+  <p>Belcak's team analyzed 125,000 resumes and found the average one matches only about half the relevant keywords for its target role, and under-indexes on soft skills specifically. Counting across a stack of postings closes exactly that gap.</p>
+</div>
+
 <p>One more thing raises the odds anyone reads the tailored version at all: a person inside the company sending it along. If you don't have that person yet, the <a href="/playbooks/get-foot-in-door-at-company">foot in the door playbook</a> covers how to build that path before or while you apply.</p>
 
 <h2 id="tailor-line-by-line">Tailor line by line</h2>
@@ -568,7 +575,7 @@ footer p { color: var(--muted); font-size: 14px; }
 <p>Use the posting's vocabulary wherever it honestly describes your work, and you've covered most of what matters. Screening software mostly stores and ranks rather than auto-rejecting, and the recruiter searching that system uses the words from their own posting. Writing for the human skimmer covers the software too.</p>
 
 <h3>What if I don't have exact numbers?</h3>
-<p>Use honest approximations of scale, team size, frequency, or before-and-after: "about 200 customers," "roughly 40 releases a year." A rounded number you can defend works better than a precise one you can't back up, and either works better than an adjective.</p>
+<p>Use honest approximations of scale, team size, frequency, or before-and-after: "about 200 customers," "roughly 40 releases a year." A rounded number you can defend works better than a precise one you can't back up, and either works better than an adjective. The teams your work feeds into usually have the numbers you lack, so ask marketing how your designs performed, or ask the person you support how many hours a week you save them; the <a href="/playbooks/resume-bullets-that-show-impact">resume bullets playbook</a> covers these scripts.</p>
 
 <h3>Should I tailor for every single application?</h3>
 <p>Do the full version for jobs you actually want. For similar roles at similar companies, one tailored version per role type covers the group, since the predicted questions barely change. Don't skip it entirely, though; the generic version you send everywhere is the weakest one you have.</p>
@@ -613,6 +620,8 @@ footer p { color: var(--muted); font-size: 14px; }
     <li>Level Up: <a href="https://www.youtube.com/watch?v=qOosv1YsHwY">Create a Bold Resume: Real Life Example</a> (Oct 2020)</li>
     <li>The Skip: <a href="https://www.youtube.com/watch?v=jYO7FupLvAM">Mastering your 30 second resume</a> (Sep 2024)</li>
     <li>Lenny's Podcast: <a href="https://www.youtube.com/watch?v=v3pofqabzhs">Lessons from one of the world's top executive recruiters, with Lauren Ipsen</a> (Nov 2022)</li>
+    <li>The Dream Job System (Austin Belcak): <a href="https://podcasts.apple.com/us/podcast/how-to-optimize-your-linkedin-skills-for-more-offers-ep-776/id1542564331?i=1000737052271">How To Optimize Your LinkedIn Skills For More Offers</a> (Nov 2025)</li>
+    <li>The Dream Job System (Austin Belcak): <a href="https://podcasts.apple.com/us/podcast/we-analyzed-125-000-resumes-heres-what-we-learned-ep-803/id1542564331?i=1000746310354">We Analyzed 125,000 Resumes, Here's What We Learned</a> (Jan 2026)</li>
   </ul>
 </div>
 

--- a/playbooks/index.html
+++ b/playbooks/index.html
@@ -3,11 +3,11 @@
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
-<meta name="description" content="59 free playbooks for the conversations that shape your career: promotions, interviews, resumes, 1:1s, feedback, and speaking with confidence. No signup, no paywall.">
+<meta name="description" content="60 free playbooks for the conversations that shape your career: promotions, interviews, resumes, 1:1s, feedback, and speaking with confidence. No signup, no paywall.">
 <meta name="color-scheme" content="light">
 <title>The Work Coach Playbooks: Free Scripts for Career Conversations | Work Coach</title>
 <link rel="canonical" href="https://work.coach/playbooks/">
-<script type="application/ld+json">{"@context":"https://schema.org","@type":"CollectionPage","headline":"The Work Coach Playbooks","description":"59 free playbooks for the conversations that shape your career: promotions, interviews, resumes, 1:1s, feedback, and speaking with confidence.","mainEntityOfPage":"https://work.coach/playbooks/"}</script>
+<script type="application/ld+json">{"@context":"https://schema.org","@type":"CollectionPage","headline":"The Work Coach Playbooks","description":"60 free playbooks for the conversations that shape your career: promotions, interviews, resumes, 1:1s, feedback, and speaking with confidence.","mainEntityOfPage":"https://work.coach/playbooks/"}</script>
 <link rel="icon" href="../img/favicon.ico">
 <link rel="icon" type="image/png" sizes="32x32" href="../img/favicon-32.png">
 <link rel="icon" type="image/png" sizes="16x16" href="../img/favicon-16.png">
@@ -17,14 +17,14 @@
 <meta property="og:url" content="https://work.coach/playbooks/">
 <meta property="og:site_name" content="Work Coach">
 <meta property="og:title" content="The Work Coach Playbooks: Free Scripts for Career Conversations">
-<meta property="og:description" content="59 free playbooks for the conversations that shape your career: promotions, interviews, resumes, 1:1s, feedback, and speaking with confidence.">
+<meta property="og:description" content="60 free playbooks for the conversations that shape your career: promotions, interviews, resumes, 1:1s, feedback, and speaking with confidence.">
 <meta property="og:image" content="https://work.coach/img/og-image-whistle.png">
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="630">
 
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="The Work Coach Playbooks: Free Scripts for Career Conversations">
-<meta name="twitter:description" content="59 free playbooks for the conversations that shape your career. No signup, no paywall.">
+<meta name="twitter:description" content="60 free playbooks for the conversations that shape your career. No signup, no paywall.">
 <meta name="twitter:image" content="https://work.coach/img/og-image-whistle.png">
 
 <script>
@@ -288,7 +288,7 @@ footer p { color: var(--muted); font-size: 14px; }
 <div class="post-hero">
   <div class="post-kicker">Free Playbooks</div>
   <h1>The playbooks for the conversations that shape your career</h1>
-  <p class="post-sub">59 free playbooks with word-for-word scripts and hard-won advice from operators who have been on the deciding side. No signup, no paywall.</p>
+  <p class="post-sub">60 free playbooks with word-for-word scripts and hard-won advice from operators who have been on the deciding side. No signup, no paywall.</p>
   <div class="cluster-toc">
       <a href="#get-promoted">Get Promoted <span class="toc-count">7</span></a>
       <a href="#job-search-resume">Job Search & Resume <span class="toc-count">14</span></a>
@@ -324,6 +324,10 @@ footer p { color: var(--muted); font-size: 14px; }
     </a>
     <a class="playbook-card" href="/playbooks/getting-honest-feedback-at-work">
       <h3>Get honest feedback at work</h3>
+      <span class="playbook-go">Read the playbook →</span>
+    </a>
+    <a class="playbook-card" href="/playbooks/how-to-get-360-feedback">
+      <h3>Get 360 feedback</h3>
       <span class="playbook-go">Read the playbook →</span>
     </a>
     <a class="playbook-card" href="/playbooks/respond-to-performance-improvement-plan">

--- a/playbooks/job-search-while-employed.html
+++ b/playbooks/job-search-while-employed.html
@@ -473,6 +473,8 @@ footer p { color: var(--muted); font-size: 14px; }
   </ul>
 </div>
 
+<p>You can also size the budget from the outcome instead of guessing: at typical stage-to-stage conversion rates, two offers take roughly 160 outreaches, and dividing that by your weekly quota tells you how many months you're signing up for. The full funnel math is in the <a href="/playbooks/stay-confident-after-job-rejection">rejection playbook</a>. And the highest-leverage hour in any employed searcher's quota is reviving dormant recruiters, the LinkedIn-inbox tactic covered in <a href="/playbooks/get-foot-in-door-at-company">the foot-in-the-door playbook</a>: an afternoon of work, invisible to your employer.</p>
+
 <p>Energy usually runs out before the hours do. Terry argues that your emotional state is the main thing to manage in a job search, and that gets harder when the search sits on top of a full week of work.</p>
 
 <div class="nugget">
@@ -595,6 +597,26 @@ footer p { color: var(--muted); font-size: 14px; }
 </div>
 
 <p>While all this is running, keep the other processes alive. A second live conversation is what keeps you from accepting a bad number out of fear that this is the only thing on the table. If a recruiter does disappear on you, <a href="/playbooks/recruiter-ghosting-after-interview">the follow-up timeline for recruiter silence</a> has the cadence and the exact messages.</p>
+
+<p>Multiple live processes eventually produce the squeeze employed searchers hit most: an offer from your second choice arrives while your first choice is still mid-process. Belcak's sequence starts by buying time from the offer in hand: <em>"Thank you for this offer. Would it be possible to get a few extra days to review it with my family? I want to feel confident when I accept."</em> Most companies give you the days, and the days are what you spend on the first choice.</p>
+
+<div class="callout">
+  <h4>The multiple-offers squeeze</h4>
+  <ul>
+    <li>Tell your first choice exactly two things: <em>"You're my top choice, and if you made me an offer I'd accept it. And I've received an offer with a deadline of [date]."</em></li>
+    <li>Companies that want you compress their process when they hear that. Belcak has seen final rounds waved entirely.</li>
+    <li>If the deadline can't be beaten, decide with full information. Accepting one offer while continuing to interview at the other company is a bridge-burner if the first choice comes through, so weigh that cost deliberately rather than discovering it later.</li>
+  </ul>
+</div>
+
+<div class="nugget">
+  <p class="nugget-lead"><strong>The Dream Job System: handling multiple interviews and offers.</strong> This one is audio only. The quote is at 1:36; the player starts from the top, or <a href="https://podcasts.apple.com/us/podcast/how-to-handle-multiple-interviews-job-offers-ep-612/id1542564331?i=1000674967114&t=96">open it on Apple Podcasts cued to 1:36</a>.</p>
+  <blockquote>"As a professional, you are the CEO of your life and your career, and you need to treat your life and your career the same way that any CEO of any company would treat their decisions."</blockquote>
+  <div class="nugget-who"><strong>Austin Belcak</strong>, Cultivated Culture · The Dream Job System</div>
+  <div class="audio-embed">
+    <iframe src="https://embed.podcasts.apple.com/us/podcast/how-to-handle-multiple-interviews-job-offers-ep-612/id1542564331?i=1000674967114&theme=auto" height="175" frameborder="0" sandbox="allow-forms allow-popups allow-same-origin allow-scripts allow-top-navigation-by-user-activation" allow="autoplay *; encrypted-media *; clipboard-write" loading="lazy" title="The Dream Job System: How To Handle Multiple Interviews &amp; Job Offers - Apple Podcasts"></iframe>
+  </div>
+</div>
 
 <h2 id="compare-the-offer-against-staying">Compare the offer against staying</h2>
 
@@ -737,6 +759,7 @@ footer p { color: var(--muted); font-size: 14px; }
     <li>Lenny's Podcast: <a href="https://www.youtube.com/watch?v=v3pofqabzhs">Lessons from one of the world's top executive recruiters, with Lauren Ipsen</a> (Nov 2022)</li>
     <li>Lenny's Podcast: <a href="https://www.youtube.com/watch?v=pEis2CBomVA">The tactical playbook for getting 20-40% more comp, with Jacob Warwick</a> (Mar 2026)</li>
     <li>WorkLife with Adam Grant: The Not-So-Great Resignation, with Anthony Klotz (Apr 2022, audio)</li>
+    <li>The Dream Job System (Austin Belcak): <a href="https://podcasts.apple.com/us/podcast/how-to-handle-multiple-interviews-job-offers-ep-612/id1542564331?i=1000674967114">How To Handle Multiple Interviews &amp; Job Offers</a> (Oct 2024)</li>
   </ul>
 </div>
 

--- a/playbooks/prepare-for-final-round-interview.html
+++ b/playbooks/prepare-for-final-round-interview.html
@@ -419,7 +419,7 @@ footer p { color: var(--muted); font-size: 14px; }
   <div class="post-kicker">Interview Prep</div>
   <h1>How to prepare for a final-round interview</h1>
   <p class="post-sub">The company already believes you can probably do the job. Use what you learned in earlier rounds to settle their remaining doubts, and to decide whether you want it.</p>
-  <div class="post-meta">12 min read</div>
+  <div class="post-meta">13 min read</div>
 </div>
 
 <main class="layout">
@@ -489,6 +489,24 @@ footer p { color: var(--muted); font-size: 14px; }
 
 <p>Pick one story for each concern. The same example can serve two interviews if you change the emphasis: the executive hears the decision and the business result, the peer hears how you got three teams to agree. If you need more stories, the <a href="/playbooks/behavioral-interview-questions">behavioral interview questions guide</a> has the full question bank and what hiring leaders listen for in the answers.</p>
 
+<p>Austin Belcak, who coaches job seekers at Cultivated Culture, pushes this mapping one step further. For each panelist, write their name, their title, what they care about, the challenges they're likely facing, and the part most candidates skip: their relationship to everyone else on the panel. Then re-cut your prepared answers per panelist, because you never know who will ask which question, and an answer that delights one panelist can rub another the wrong way.</p>
+
+<p>His worked example: a PM role sitting between engineering and sales, where sales keeps promising features that don't exist. Asked "tell me about a difficult person," the answer the engineering manager wants to hear is about protecting a team's roadmap; the answer the salesperson wants is about enabling a team against someone constraining it. You need a version that works in the room where both are sitting, which usually means a story where the difficult person is outside the functions represented on the panel.</p>
+
+<div class="callout">
+  <h4>Belcak's Q&amp;A Rule for Panels</h4>
+  <p>Prepare two or three questions per panelist, and ask each person at least one aimed at their seat. Nobody on the panel should leave without fielding a question written for them.</p>
+</div>
+
+<div class="nugget">
+  <p class="nugget-lead"><strong>The Dream Job System: preparing for panel interviews.</strong> This one is audio only. The quote is at 7:46; the player starts from the top, or <a href="https://podcasts.apple.com/us/podcast/the-best-way-to-prepare-for-panel-interviews-ep-259/id1542564331?i=1000571303506&t=466">open it on Apple Podcasts cued to 7:46</a>.</p>
+  <blockquote>"If the engineering manager asks this question, you want to make sure that you give an example and an answer that speaks directly to the pain points that they're facing, while also not throwing the salesperson under the bus."</blockquote>
+  <div class="nugget-who"><strong>Austin Belcak</strong>, Cultivated Culture · The Dream Job System</div>
+  <div class="audio-embed">
+    <iframe src="https://embed.podcasts.apple.com/us/podcast/the-best-way-to-prepare-for-panel-interviews-ep-259/id1542564331?i=1000571303506&theme=auto" height="175" frameborder="0" sandbox="allow-forms allow-popups allow-same-origin allow-scripts allow-top-navigation-by-user-activation" allow="autoplay *; encrypted-media *; clipboard-write" loading="lazy" title="The Dream Job System: The Best Way To Prepare For Panel Interviews - Apple Podcasts"></iframe>
+  </div>
+</div>
+
 <h2 id="answer-the-objection-nobody-has-said-out-loud">Answer the objection nobody has said out loud</h2>
 
 <p>Most final-round doubts fall into a few familiar categories: you'd be stepping up to a bigger scope, you're coming from a different industry, you'd be managing former peers, you have a short tenure to explain, or you'd be moving from doing the work to leading it. You usually know which one applies to you. Prepare a factual answer with three parts: acknowledge the difference, show the closest evidence you have, and explain how you'd close the rest of the gap.</p>
@@ -533,6 +551,8 @@ footer p { color: var(--muted); font-size: 14px; }
 </ol>
 
 <p>Label your assumptions clearly. Saying "here's what I'd want to verify first" shows you've thought about the order of the work without pretending to know things only insiders know.</p>
+
+<p>If you've built something more substantial, a deck analyzing the company's product or strategy, what Belcak calls a value validation project, the send timing matters as much as the content. His rule: for a morning interview, email it around 4pm the day before; for an afternoon interview, a couple of hours ahead. Close enough to the interview that it's fresh, with the deep walkthrough happening live, where you can present it properly. And if nobody brings it up, wait for a relevant hypothetical and offer: <em>"I actually put together a deliverable on exactly that, happy to share my screen and walk you through it."</em></p>
 
 <h2 id="ask-questions-that-help-you-decide">Ask questions that help you decide</h2>
 
@@ -649,6 +669,8 @@ footer p { color: var(--muted); font-size: 14px; }
     <li>Lenny's Podcast: <a href="https://www.youtube.com/watch?v=OH3nzRdwYPA">Land your dream job in today's market, with Phyl Terry</a> (Sep 2024)</li>
     <li>Lenny's Podcast: <a href="https://www.youtube.com/watch?v=v3pofqabzhs">Lessons from one of the world's top executive recruiters, with Lauren Ipsen</a> (Nov 2022)</li>
     <li>Lenny's Podcast: <a href="https://www.youtube.com/watch?v=LpbBzmXrzEY">How to speak more confidently and persuasively, with Matt Abrahams</a> (Mar 2024)</li>
+    <li>The Dream Job System (Austin Belcak): <a href="https://podcasts.apple.com/us/podcast/the-best-way-to-prepare-for-panel-interviews-ep-259/id1542564331?i=1000571303506">The Best Way To Prepare For Panel Interviews</a> (Jul 2022)</li>
+    <li>The Dream Job System (Austin Belcak): <a href="https://podcasts.apple.com/us/podcast/when-how-you-should-share-a-value-validation-project-ep-667/id1542564331?i=1000698231101">When (&amp; How) You Should Share A Value Validation Project</a> (Mar 2025)</li>
   </ul>
 </div>
 

--- a/playbooks/prepare-for-interview-in-24-hours.html
+++ b/playbooks/prepare-for-interview-in-24-hours.html
@@ -419,7 +419,7 @@ footer p { color: var(--muted); font-size: 14px; }
   <div class="post-kicker">Interview Prep</div>
   <h1>How to prepare for a job interview in 24 hours</h1>
   <p class="post-sub">Your interview is tomorrow. Here is how to spend the day so you walk in with a role brief, three stories, and answers you've already said out loud.</p>
-  <div class="post-meta">13 min read</div>
+  <div class="post-meta">14 min read</div>
 </div>
 
 <main class="layout">
@@ -575,6 +575,22 @@ footer p { color: var(--muted); font-size: 14px; }
 
 <p>Make a one-page question map: likely question on the left, the story, evidence, or research note you'll use on the right. One strong example can answer several prompts when you shift the emphasis.</p>
 
+<p>With only hours available, don't guess at questions when you can look them up. Austin Belcak, who coaches job seekers at Cultivated Culture, uses two sources fast enough to fit this window. First, Glassdoor's Interviews tab for the company: filter by your job title, tally the questions that repeat across reviews, and prepare the top of the list first. The whole exercise fits inside an hour. Second, the job description itself: every requirement line implies a question, so turn each one into the question an interviewer would ask, and you have a predicted list that covers most of the interview.</p>
+
+<div class="callout">
+  <h4>Turning a Requirement into a Question</h4>
+  <p>"Dynamic people manager with a knack for complex problems" becomes "tell me about a time your team solved a complex problem." With a day, run it on the five or six requirement lines your scorecard already flagged as central, and match each question to a story or research note before moving on.</p>
+</div>
+
+<div class="nugget">
+  <p class="nugget-lead"><strong>The Dream Job System: mining the questions they actually asked.</strong> This one is audio only. The quote is at 4:18; the player starts from the top, or <a href="https://podcasts.apple.com/us/podcast/how-to-anticipate-every-interview-question-in-3-steps-ep-842/id1542564331?i=1000769775701&t=258">open it on Apple Podcasts cued to 4:18</a>.</p>
+  <blockquote>"Now you essentially have a prioritized roadmap of additional questions to prepare for. And if these are common questions and you already have answers prepared, awesome. But what you're going to find here is some of those case study questions, some of those role-specific questions."</blockquote>
+  <div class="nugget-who"><strong>Austin Belcak</strong>, Cultivated Culture · The Dream Job System</div>
+  <div class="audio-embed">
+    <iframe src="https://embed.podcasts.apple.com/us/podcast/how-to-anticipate-every-interview-question-in-3-steps-ep-842/id1542564331?i=1000769775701&theme=auto" height="175" frameborder="0" sandbox="allow-forms allow-popups allow-same-origin allow-scripts allow-top-navigation-by-user-activation" allow="autoplay *; encrypted-media *; clipboard-write" loading="lazy" title="The Dream Job System: How To Anticipate Every Interview Question In 3 Steps - Apple Podcasts"></iframe>
+  </div>
+</div>
+
 <h3>Motivation and fit</h3>
 
 <ul>
@@ -629,6 +645,18 @@ footer p { color: var(--muted); font-size: 14px; }
     <li>"Is there anything in my background the team wants to explore in more depth?"</li>
   </ul>
 </div>
+
+<div class="callout">
+  <h4>Four Additions from Belcak's Field Testing</h4>
+  <ul>
+    <li>"Fast forward a year: what did this hire do to exceed every expectation?" It gets you the real success criteria.</li>
+    <li>"Why is this role open?" Expansion, backfill, and turnover each tell you something different about what you're walking into.</li>
+    <li>"Who would NOT be a good fit here?" It flips the canned culture answer into a real one.</li>
+    <li>"Can you walk me through the roadmap for the next 12 months?" Healthy companies answer it; struggling ones dance around it.</li>
+  </ul>
+</div>
+
+<p>When time runs out before your list does, Belcak's close is worth borrowing: ask <em>"would it be all right if I emailed you a couple more questions I had about the team?"</em> It reads as respect for their time, and it gets you the interviewer's email address for the thank-you note.</p>
 
 <p>End with a process question: "Is there anything else I can clarify, and what are the next steps?" It gives the interviewer a chance to surface a concern while you're still in the conversation.</p>
 
@@ -794,6 +822,9 @@ footer p { color: var(--muted); font-size: 14px; }
     <li>Lenny's Podcast: <a href="https://www.youtube.com/watch?v=OH3nzRdwYPA">Land your dream job in today's market, with Phyl Terry</a> (Sep 2024)</li>
     <li>Lenny's Podcast: <a href="https://www.youtube.com/watch?v=v3pofqabzhs">Lessons from one of the world's top executive recruiters, with Lauren Ipsen</a> (Nov 2022)</li>
     <li>Lenny's Podcast: <a href="https://www.youtube.com/watch?v=LpbBzmXrzEY">How to speak more confidently and persuasively, with Matt Abrahams</a> (Mar 2024)</li>
+    <li>The Dream Job System (Austin Belcak): <a href="https://podcasts.apple.com/us/podcast/how-to-anticipate-every-interview-question-in-3-steps-ep-842/id1542564331?i=1000769775701">How To Anticipate Every Interview Question In 3 Steps</a> (May 2026)</li>
+    <li>The Dream Job System (Austin Belcak): <a href="https://podcasts.apple.com/us/podcast/a-4-step-framework-for-highly-effective-interview/id1542564331?i=1000776224786">A 4 Step Framework For Highly Effective Interview Prep</a> (Jul 2026)</li>
+    <li>The Dream Job System (Austin Belcak): <a href="https://podcasts.apple.com/us/podcast/9-unique-questions-to-ask-in-your-next-interview-ep-728/id1542564331?i=1000719458230">9 Unique Questions To Ask In Your Next Interview</a> (Jul 2025)</li>
   </ul>
 </div>
 

--- a/playbooks/resume-bullets-that-show-impact.html
+++ b/playbooks/resume-bullets-that-show-impact.html
@@ -476,6 +476,29 @@ footer p { color: var(--muted); font-size: 14px; }
 
 <p>One more constraint worth knowing before you start. Asked how many bullets a job should get, Evans said he has no idea what the right number is, but the key is to "drive to the point": what you were responsible for, what you did, what results and value you created, what skills you learned. If your bullets run several lines each, you need fewer of them, and one-line bullets let you run a few more. Length follows from how fast each line gets to the point.</p>
 
+<p>If you want a more mechanical calibration, Austin Belcak's team at Cultivated Culture tested bullet composition across thousands of job seekers and landed on a formula their free scoring tool still uses:</p>
+
+<div class="callout">
+  <h4>The tested composition</h4>
+  <ul>
+    <li><strong>12 to 20 words long.</strong> Most bullets that run past 20 are carrying words the reader skips.</li>
+    <li><strong>About a third industry skills and keywords</strong>, the terms a hiring manager and an ATS are both scanning for.</li>
+    <li><strong>One or two measurable results</strong>, roughly 15 percent of the line.</li>
+    <li><strong>A strong action verb</strong>, another 15 percent: spearheaded, eliminated, led, not "responsible for."</li>
+    <li><strong>The rest connective words</strong> that keep it a readable sentence.</li>
+  </ul>
+  <p>His worked example checks every box: "Developed a tiered triage system that eliminated 40% of Jira ticket backlog in less than eight weeks." Don't treat the percentages as gospel; treat them as a linter for bullets that are all keywords and no outcome, or all story and no substance.</p>
+</div>
+
+<div class="nugget">
+  <p class="nugget-lead"><strong>The Dream Job System: the resume bullet formula.</strong> This one is audio only. The quote is at 8:33; the player starts from the top, or <a href="https://podcasts.apple.com/us/podcast/my-formula-for-crazy-effective-resume-bullets-ep-853/id1542564331?i=1000773687910&t=513">open it on Apple Podcasts cued to 8:33</a>.</p>
+  <blockquote>"You don't want to be summarizing your experience. You want to be selling it. If you start selling your value, if you start selling your experience, that is where you're going to start winning more interviews and more job offers from your resume."</blockquote>
+  <div class="nugget-who"><strong>Austin Belcak</strong>, Cultivated Culture · The Dream Job System</div>
+  <div class="audio-embed">
+    <iframe src="https://embed.podcasts.apple.com/us/podcast/my-formula-for-crazy-effective-resume-bullets-ep-853/id1542564331?i=1000773687910&theme=auto" height="175" frameborder="0" sandbox="allow-forms allow-popups allow-same-origin allow-scripts allow-top-navigation-by-user-activation" allow="autoplay *; encrypted-media *; clipboard-write" loading="lazy" title="The Dream Job System: My Formula For Crazy-Effective Resume Bullets - Apple Podcasts"></iframe>
+  </div>
+</div>
+
 <h2 id="rewriting-ten-real-bullets">Rewriting ten real bullets</h2>
 
 <p>The patterns below cover almost every weak bullet we see. Find yours, then copy the shape of the rewrite.</p>
@@ -559,7 +582,7 @@ footer p { color: var(--muted); font-size: 14px; }
 
 <h2 id="how-to-find-the-number-when-you-think-you-don-t-have-one">How to find the number when you think you don't have one</h2>
 
-<p>Most people say their work can't be measured. Usually they've just never sat down and looked for a number. Evans ran into this on a senior product manager's resume, where one bullet happened to mention a billion in revenue and the rest said nothing about outcomes at all.</p>
+<p>Most people say their work can't be measured. Usually they've just never sat down and looked for a number, and the bar is lower than you'd think: when Cultivated Culture analyzed 125,000 resumes run through their scanner, <strong>36 percent contained no metrics at all</strong>, and only 26 percent had five or more. A handful of defensible numbers puts you in the top quartile of the stack. Evans ran into the problem on a senior product manager's resume, where one bullet happened to mention a billion in revenue and the rest said nothing about outcomes at all.</p>
 
 <div class="nugget">
   <p class="nugget-lead"><strong>Asking for the result on every line.</strong> The player below is queued to 8:22, the exact moment Ethan Evans asks for it. <a href="https://www.youtube.com/watch?v=qumzVnGdsSc&t=502s">Watch on YouTube</a>.</p>
@@ -590,8 +613,11 @@ footer p { color: var(--muted); font-size: 14px; }
     <li>Slack messages where someone thanked you, which usually name the thing that got better.</li>
     <li>The launch email or the postmortem, which almost always has the before and after in it.</li>
     <li>Colleagues who were there. Ask them what changed after you did the work.</li>
+    <li>The team your work feeds into. If your own work has no dashboard, theirs probably does.</li>
   </ul>
 </div>
+
+<p>That last one is the move most people never make, and Belcak has scripts for it. A graphic designer has no revenue number, but the marketing team running their ads does: <em>"Those Facebook ads I designed for you, how did they perform against our previous campaigns? Is there a report you could send me?"</em> comes back as "designed ad creative that lifted conversion rates 60%." An executive assistant can ask the person they support directly: <em>"Ballpark, how many hours a week do you think I save you?"</em> Whatever team consumes your work, sales, marketing, support, ask them what moved. Their numbers are your numbers, because your work is inside them.</p>
 
 <p>If this feels uncomfortable, you're not the only one. Plenty of people go blank here because writing down their own results feels like bragging. Deb Liu hears it constantly when she asks people about their self-reviews, and her answer reframes the whole exercise.</p>
 
@@ -695,7 +721,7 @@ footer p { color: var(--muted); font-size: 14px; }
 <h2 id="frequently-asked-questions">Frequently asked questions</h2>
 
 <h3>How many bullets should each job get?</h3>
-<p>Evans says there's no ideal number and the real constraint is how fast each line gets to the point. In practice: four to six for your current role, three to four for the one before, one or two for anything older than about ten years. Long multi-line bullets mean you need fewer of them.</p>
+<p>Evans says there's no ideal number and the real constraint is how fast each line gets to the point. In practice: four to six for your current role, three to four for the one before, one or two for anything older than about ten years. Long multi-line bullets mean you need fewer of them. Belcak's structure for whatever count you land on: make the first bullet a summary of the role's scope, then use the rest as case studies, specific projects that prove the summary.</p>
 
 <h3>What if my results took a whole team?</h3>
 <p>Most results do, and hiring managers know that. Name the team result and your specific part in it. "Grew the team from 4 to 11 engineers" as the hiring lead is honest even though you weren't the only interviewer. What you can't do is present a team number in a way that implies you did all of it, because that unravels in the first follow-up question.</p>
@@ -751,6 +777,10 @@ footer p { color: var(--muted); font-size: 14px; }
     <li>Level Up: <a href="https://www.youtube.com/watch?v=qOosv1YsHwY">Create a Bold Resume: Real Life Example</a> (Oct 2020)</li>
     <li>Lenny's Podcast: <a href="https://www.youtube.com/watch?v=MajB5CQUKDA">Succeeding as an introvert, building zero-to-one, and PM'ing your career like a product, with Deb Liu</a> (Aug 2024)</li>
     <li>Lenny's Podcast: <a href="https://www.youtube.com/watch?v=v3pofqabzhs">Lessons from one of the world's top executive recruiters, with Lauren Ipsen</a> (Nov 2022)</li>
+    <li>The Dream Job System (Austin Belcak): <a href="https://podcasts.apple.com/us/podcast/my-formula-for-crazy-effective-resume-bullets-ep-853/id1542564331?i=1000773687910">My Formula For Crazy-Effective Resume Bullets</a> (Jun 2026)</li>
+    <li>The Dream Job System (Austin Belcak): <a href="https://podcasts.apple.com/us/podcast/we-analyzed-125-000-resumes-heres-what-we-learned-ep-803/id1542564331?i=1000746310354">We Analyzed 125,000 Resumes, Here's What We Learned</a> (Jan 2026)</li>
+    <li>The Dream Job System (Austin Belcak): <a href="https://podcasts.apple.com/us/podcast/how-to-illustrate-value-on-a-resume-in-a-non/id1542564331?i=1000657892991">How To Illustrate Value On A Resume In A Non-Numbers Focused Role</a> (Jun 2024)</li>
+    <li>The Dream Job System (Austin Belcak): <a href="https://podcasts.apple.com/us/podcast/one-page-vs-multi-pages-resumes-which-is-better-ep-823/id1542564331?i=1000758996832">One Page vs. Multi Pages Resumes - Which Is Better?</a> (Apr 2026)</li>
   </ul>
 </div>
 

--- a/playbooks/resume-for-career-change.html
+++ b/playbooks/resume-for-career-change.html
@@ -419,7 +419,7 @@ footer p { color: var(--muted); font-size: 14px; }
   <div class="post-kicker">Job Search</div>
   <h1>How to write a resume when you're changing careers</h1>
   <p class="post-sub">Name the problems the new role exists to solve, then show the work from your old field as evidence you can solve them. Don't leave the translating to the reader.</p>
-  <div class="post-meta">13 min read</div>
+  <div class="post-meta">14 min read</div>
 </div>
 
 <main class="layout">
@@ -446,6 +446,10 @@ footer p { color: var(--muted); font-size: 14px; }
 <p>He hit the same thing reviewing a finance manager who'd started a company: "What job are you after? Maybe you customize that for specific jobs, but be clear about what you want, because you're all over the place here." The fix is one line at the top of the page naming the role you're applying for. It costs you nothing and it tells the reader which lens to read the rest through.</p>
 
 <p>So write that line before anything else, and be specific. "Product marketing manager at a B2B software company" gives you something to aim at. "Looking to leverage my skills in a new challenge" is the sentence career changers reach for when they haven't decided yet, and a reader can tell.</p>
+
+<p>Part of picking the target is being honest about how far away it is. Austin Belcak, who coaches job seekers at Cultivated Culture, breaks any job move into three variables: title, company, and industry. Change one and you're on the easy setting. Change two at once and the search gets exponentially harder. Change all three and you should expect a much longer search than any benchmark timeline suggests, because those benchmarks come from people changing one.</p>
+
+<p>The stepping-stone play is to sequence the changes instead of making them all at once. Belcak's example: finance to graphic design isn't one jump. Take the design role at a financial institution first, where your finance fluency is an asset rather than a detour, and make the industry change in the following move.</p>
 
 <h2 id="check-that-the-market-will-give-you-that-role">Check that the market will give you that role</h2>
 
@@ -482,6 +486,28 @@ footer p { color: var(--muted); font-size: 14px; }
 <p>The evidence is usually already on your resume, sitting in the wrong place. Reviewing a resume from a 20-year Army veteran moving into industry, Evans found the strongest fact on the page "buried in here near the bottom": the applicant had managed a $450 million budget. Everything above it was training jargon.</p>
 
 <p>What he said next is what a career change resume has to do. "That's amazing. How do you convey that? How do you get that up at the top of your resume? Because in the business world, that's what I want. I'm looking for that business impact and business ability." You already know which of your facts would impress someone in the new field. The reader doesn't, and won't go hunting for them.</p>
+
+<p>When the table shows more nos than yeses, you don't have to wait for a job to grant you the evidence. Belcak has five ways to build it.</p>
+
+<div class="callout">
+  <h4>Five ways to build the evidence</h4>
+  <ul>
+    <li><strong>Volunteer where yes comes easy.</strong> Nonprofits, local businesses, and early-stage startups will trade experience and a reference for free work. His pitch: <em>"I'm moving from X into Y and building my experience — I'd love to volunteer my services and get in on the ground floor of this space."</em></li>
+    <li><strong>Freelance up a ladder.</strong> He started at $50 a month running Google Ads for local businesses, raised rates $25-50 with each new client, and had case studies within months.</li>
+    <li><strong>Publish 25 posts in 30 days</strong> on the target field. The writing forces the education, the deadline kills perfectionism, and the byline puts you in front of the people already working there.</li>
+    <li><strong>Start a small interview podcast.</strong> The person who won't take your "pick your brain" coffee will say yes to being interviewed, and you get double the time.</li>
+    <li><strong>Audit a target company.</strong> Pick one from your list, study their strategy, and write up three improvements. The finished audit doubles as the work sample you lead with in outreach.</li>
+  </ul>
+</div>
+
+<div class="nugget">
+  <p class="nugget-lead"><strong>The Dream Job System: how the freelance ladder starts.</strong> This one is audio only. The quote is at 4:46; the player starts from the top, or <a href="https://podcasts.apple.com/us/podcast/5-ways-to-build-experience-when-changing-careers-ep-264/id1542564331?i=1000575335044&t=286">open it on Apple Podcasts cued to 4:46</a>.</p>
+  <blockquote>"I wasn't the leading expert on paid Google ads or SEO or websites or any of this stuff, but I knew more than my clients. And they were willing to pay me, especially given that my rates were significantly lower than the folks who were full-fledged experts."</blockquote>
+  <div class="nugget-who"><strong>Austin Belcak</strong>, Cultivated Culture · The Dream Job System</div>
+  <div class="audio-embed">
+    <iframe src="https://embed.podcasts.apple.com/us/podcast/5-ways-to-build-experience-when-changing-careers-ep-264/id1542564331?i=1000575335044&theme=auto" height="175" frameborder="0" sandbox="allow-forms allow-popups allow-same-origin allow-scripts allow-top-navigation-by-user-activation" allow="autoplay *; encrypted-media *; clipboard-write" loading="lazy" title="The Dream Job System: 5 Ways To Build Experience When Changing Careers - Apple Podcasts"></iframe>
+  </div>
+</div>
 
 <h2 id="be-honest-about-which-skills-actually-transfer">Be honest about which skills actually transfer</h2>
 
@@ -657,7 +683,7 @@ footer p { color: var(--muted); font-size: 14px; }
 <p>No. Recruiters see that format and assume you're hiding something, and it removes the dates and titles they use to place you. Keep the reverse chronological structure and do the work inside it: target role at the top, evidence bullets reordered so the transferable work leads, old-field detail compressed.</p>
 
 <h3>How do I handle having zero experience in the new field?</h3>
-<p>You almost never have zero. You have work that solved the same kind of problem in a different setting, and your job is to describe it in the new field's terms. If you genuinely can't find any, that's a signal to go get some before you apply: a side project, a volunteer role, a piece of the new work inside your current job, or a bridge role.</p>
+<p>You almost never have zero. You have work that solved the same kind of problem in a different setting, and your job is to describe it in the new field's terms. If you genuinely can't find any, that's a signal to go get some before you apply: a side project, a volunteer role, a piece of the new work inside your current job, or a bridge role. Once you have it, put it first: Belcak opens career-change resumes with a section titled for the target role, a "Marketing Summary," holding one summary bullet plus case studies drawn from the evidence you built above. The first thing a screener reads is the claim, not the old career.</p>
 
 <h3>Do I need a cover letter for a career change?</h3>
 <p>Yes, more than most applicants do. It's the one place you get a paragraph to connect the old work to the new role without cluttering the resume. Three short paragraphs: the role you want and why now, one specific project from your old field that proves you can do the central thing this job requires, and what drew you to this company. Keep it under 200 words.</p>
@@ -716,6 +742,9 @@ footer p { color: var(--muted); font-size: 14px; }
     <li>Level Up: <a href="https://www.youtube.com/watch?v=_BY3DTlSbl0">How To Plan A Career Change, with Matt McCloskey</a> (Mar 2021)</li>
     <li>Lenny's Podcast: <a href="https://www.youtube.com/watch?v=OH3nzRdwYPA">Land your dream job in today's market, with Phyl Terry</a> (Sep 2024)</li>
     <li>Lenny's Podcast: <a href="https://www.youtube.com/watch?v=v3pofqabzhs">Lessons from one of the world's top executive recruiters, with Lauren Ipsen</a> (Nov 2022)</li>
+    <li>The Dream Job System (Austin Belcak): <a href="https://podcasts.apple.com/us/podcast/the-3-levels-of-job-search-difficulty-ep-750/id1542564331?i=1000727152093">The 3 Levels Of Job Search Difficulty</a> (Sep 2025)</li>
+    <li>The Dream Job System (Austin Belcak): <a href="https://podcasts.apple.com/us/podcast/5-ways-to-build-experience-when-changing-careers-ep-264/id1542564331?i=1000575335044">5 Ways To Build Experience When Changing Careers</a> (Aug 2022)</li>
+    <li>The Dream Job System (Austin Belcak): <a href="https://podcasts.apple.com/us/podcast/how-to-level-up-your-resume-with-a-highlight-reel-ep-867/id1542564331?i=1000778155856">How To Level Up Your Resume With A "Highlight Reel"</a> (Jul 2026)</li>
   </ul>
 </div>
 

--- a/playbooks/resume-with-no-experience.html
+++ b/playbooks/resume-with-no-experience.html
@@ -496,6 +496,26 @@ footer p { color: var(--muted); font-size: 14px; }
 
 <p>Two format warnings, because he raised them on almost every student resume. Give it white space. Reviewing a Waterloo student's page, he said the density itself was the problem: "It's about it being readable, and this is so dense the readability suffers." His reaction as the person holding a thousand resumes was blunt: "basically what that does for me as a reviewer is it irritates me, because now I have to do the work to sort of parse through your bad design." And spell out your acronyms. He hit "DECA" on that same resume and said "this is kind of meaningless to me," then suggested writing it as "DECA (high school marketing)" so a reader outside your world can follow.</p>
 
+<p>There's an alternative to opening with education worth testing. Austin Belcak, who coaches job seekers at Cultivated Culture, opens the page with what he calls a Highlight Reel: a custom section titled for the target role, "Sales Summary" for an account executive application, holding three to five bullets. The section title does the positioning before anyone reads a line of the resume.</p>
+
+<div class="callout">
+  <h4>The Highlight Reel</h4>
+  <ul>
+    <li><strong>One summary line.</strong> Who you are and what you're aiming at, with any number or social proof you have.</li>
+    <li><strong>Two or three case-study bullets.</strong> Projects, class work, internships, each with a result.</li>
+    <li><strong>One culture bullet.</strong> Volunteering, communities, initiatives you helped run.</li>
+  </ul>
+</div>
+
+<div class="nugget">
+  <p class="nugget-lead"><strong>The Dream Job System: the highlight reel.</strong> This one is audio only. The quote is at 2:30; the player starts from the top, or <a href="https://podcasts.apple.com/us/podcast/how-to-level-up-your-resume-with-a-highlight-reel-ep-867/id1542564331?i=1000778155856&t=150">open it on Apple Podcasts cued to 2:30</a>.</p>
+  <blockquote>"Real world results always trump education. That's just the truth in pretty much any industry that you're in."</blockquote>
+  <div class="nugget-who"><strong>Austin Belcak</strong>, Cultivated Culture · The Dream Job System</div>
+  <div class="audio-embed">
+    <iframe src="https://embed.podcasts.apple.com/us/podcast/how-to-level-up-your-resume-with-a-highlight-reel-ep-867/id1542564331?i=1000778155856&theme=auto" height="175" frameborder="0" sandbox="allow-forms allow-popups allow-same-origin allow-scripts allow-top-navigation-by-user-activation" allow="autoplay *; encrypted-media *; clipboard-write" loading="lazy" title="The Dream Job System: How To Level Up Your Resume With A &quot;Highlight Reel&quot; - Apple Podcasts"></iframe>
+  </div>
+</div>
+
 <h2 id="write-project-bullets-the-way-you-d-write-a-job">Write project bullets the way you'd write a job</h2>
 
 <p>This is where most entry-level resumes lose. When you describe a course project the way your syllabus describes it, a reader sees homework. When you describe the same project the way you'd describe a job, a reader sees work, and almost all of that difference comes down to whether the bullet ends in a result.</p>
@@ -547,6 +567,8 @@ footer p { color: var(--muted); font-size: 14px; }
 <p>He graded that resume a B for missing results generally, then dropped it to a C minus because a finance major with no numbers on the page undercuts the whole application. The lesson generalizes past finance: whatever you claim to be good at, the page should show you doing it.</p>
 
 <p>You don't need audited figures, just honest scale. How many customers a shift, how many hours a week, how many people on the team, how many dollars in the budget, how many rows in the dataset, what it was before and after. Use a rounded number you can defend in an interview, and use it in place of an adjective.</p>
+
+<p>When your own work has no dashboard, borrow one. Belcak's scripts for this work at any experience level: the club treasurer can ask "how did attendance move after the events I ran?", and the intern who made ad graphics can ask the marketing team how those ads performed against the average. Whoever consumed your work has numbers about it, and one conversation usually converts "helped with social media" into "designed posts that lifted engagement 40%."</p>
 
 <p>While you're adding numbers, take out the inflated vocabulary. Evans hit a resume stacked with "executed, strategized and designed" and "hypothesized, conducted and analyzed A/B tests" and called it out: "you've like decided there's extra points for syllables, and it just sounds a little overblown." A plain verb with a real number after it does more for you than an impressive verb with nothing after it.</p>
 
@@ -709,6 +731,8 @@ footer p { color: var(--muted); font-size: 14px; }
     <li>Level Up: <a href="https://www.youtube.com/watch?v=9fjPmfd1YKA">Real Resume Review: ASU Chemical Engineering Student</a> (Feb 2021)</li>
     <li>Level Up: <a href="https://www.youtube.com/watch?v=-7JNJ8ELCzI">Real Resume Review: Entry Level, Software Development Engineer</a> (Jan 2021)</li>
     <li>The Skip: <a href="https://www.youtube.com/watch?v=VPw6H4sStzQ">Graduating Into Uncertainty? How to Actually Land Your First Tech Job</a> (Jul 2025)</li>
+    <li>The Dream Job System (Austin Belcak): <a href="https://podcasts.apple.com/us/podcast/how-to-level-up-your-resume-with-a-highlight-reel-ep-867/id1542564331?i=1000778155856">How To Level Up Your Resume With A "Highlight Reel"</a> (Jul 2026)</li>
+    <li>The Dream Job System (Austin Belcak): <a href="https://podcasts.apple.com/us/podcast/how-to-illustrate-value-on-a-resume-in-a-non/id1542564331?i=1000657892991">How To Illustrate Value On A Resume In A Non-Numbers Focused Role</a> (Jun 2024)</li>
   </ul>
 </div>
 

--- a/playbooks/salary-negotiation-scripts.html
+++ b/playbooks/salary-negotiation-scripts.html
@@ -419,7 +419,7 @@ footer p { color: var(--muted); font-size: 14px; }
   <div class="post-kicker">Negotiation</div>
   <h1>Salary negotiation scripts: how to get 20-40% more without sounding greedy</h1>
   <p class="post-sub">Jacob Warwick has negotiated over a billion dollars in executive comp. Chris Voss negotiated hostages for the FBI. Their scripts, word for word, linked to the moments they explain them.</p>
-  <div class="post-meta">12 min read</div>
+  <div class="post-meta">14 min read</div>
 </div>
 
 <main class="layout">
@@ -443,7 +443,18 @@ footer p { color: var(--muted); font-size: 14px; }
   </div>
 </div>
 
-<p>Companies expect the ask. The offer has room built into it. What follows is how to use that room without damaging the relationship you are about to start.</p>
+<p>Austin Belcak, who coaches job seekers at Cultivated Culture, sees the same result in his own LinkedIn polls, with samples of 15,000-plus:</p>
+
+<div class="nugget">
+  <p class="nugget-lead"><strong>The Dream Job System: surveying 115K+ people on salary negotiation.</strong> This one is audio only. The quote is at 2:28; the player starts from the top, or <a href="https://podcasts.apple.com/us/podcast/4-takeaways-from-surveying-115k-people-on-salary-negotiation/id1542564331?i=1000723676975&t=148">open it on Apple Podcasts cued to 2:28</a>.</p>
+  <blockquote>"The moral of the story here is that 92% of people who negotiated got more than what was originally offered to them. So that is why it's crazy to me that less than half of the folks out there actually went out and negotiated salary for their last role."</blockquote>
+  <div class="nugget-who"><strong>Austin Belcak</strong>, Cultivated Culture · The Dream Job System</div>
+  <div class="audio-embed">
+    <iframe src="https://embed.podcasts.apple.com/us/podcast/4-takeaways-from-surveying-115k-people-on-salary-negotiation/id1542564331?i=1000723676975&theme=auto" height="175" frameborder="0" sandbox="allow-forms allow-popups allow-same-origin allow-scripts allow-top-navigation-by-user-activation" allow="autoplay *; encrypted-media *; clipboard-write" loading="lazy" title="The Dream Job System: 4 Takeaways From Surveying 115K+ People On Salary Negotiation - Apple Podcasts"></iframe>
+  </div>
+</div>
+
+<p>He also modeled what staying silent costs over a career: two people who start at $50,000 and change jobs five times over 30 years end up <strong>more than $560,000 apart</strong>, purely on whether one of them negotiated each move. Companies expect the ask. The offer has room built into it. What follows is how to use that room without damaging the relationship you are about to start.</p>
 
 <h2 id="stage-1-the-recruiter-asks-for-your-number">Stage 1: The recruiter asks for your number</h2>
 
@@ -459,6 +470,18 @@ footer p { color: var(--muted); font-size: 14px; }
 </div>
 
 <p>His reasoning (27:55): you should never be so sure of what you are worth that you would not accept more. Interviews expand the role as the company gets to know you. Give a number on day one and it gets anchored to the smallest version of the role.</p>
+
+<p>Some recruiter screens won't move forward without a number. Austin Belcak's fallback is to flip the question once before conceding: <em>"I completely understand, and I don't want to waste anyone's time either. Since you seem to have a range in mind, would you be open to sharing the range you've budgeted for this role?"</em> Recruiters share it more often than you'd expect, and then you never have to name a number at all; "that's in line with the other roles I'm being considered for" does the rest.</p>
+
+<div class="callout">
+  <h4>If you must name a range</h4>
+  <p>Belcak's two construction rules:</p>
+  <ul>
+    <li><strong>Build it at the 70th to 80th percentile</strong> of the researched range for the role, above average but not at the extreme.</li>
+    <li><strong>Put the number you actually want at the bottom of the range.</strong> People latch onto the low number, the same way you read a "$70-80K" posting and think $80K. If you want $80K, say "$80,000 to $90,000."</li>
+  </ul>
+  <p>Then deliver it with the market doing the talking: <em>"I'm currently being considered for roles in the range of X to Y, but my number one priority is finding the right fit."</em> The market valued you at that range; you're not claiming you deserve it, so there's nothing to defend.</p>
+</div>
 
 <h2 id="stage-2-the-offer-lands">Stage 2: The offer lands</h2>
 
@@ -504,6 +527,8 @@ footer p { color: var(--muted); font-size: 14px; }
 </div>
 
 <p>He describes clients who entered processes scoped at $185K to $285K and closed at $1.1M, not by pushing the band but by resetting which band the conversation was in.</p>
+
+<p>There's a smaller version of the same move for anyone who already gave a number early and regrets it. You can't just ask for more; you need something to have changed, and something almost always has: the role you priced on the first call is not the role you understand after four rounds of interviews. Belcak's recovery script names the change directly: <em>"When I shared that number, it was based on what I knew from our first conversation. Through this process I've learned a lot about the goals and expectations for this role, and given the scope, I believe this number better aligns with the value I'd bring to the team."</em> If nothing obvious changed, ask a question whose answer might change it: career coach Adam Broda suggests asking how many hours a week the role really expects. Any answer above forty legitimately reprices the number you gave for a forty-hour week.</p>
 
 <p>Worth knowing from the employer's side: salary bands come out of formulas someone chose. Matt Mochary's curriculum, used by CEOs at OpenAI and Coinbase, shows founders an explicit formula for offers: market comp minus your cash salary, multiplied over four years, divided by an optimism factor, paid as equity. It also advises setting cash at "what you need to live comfortably," which means volunteering a low cash need lowers your cash offer. And when a company offers you a menu of cash/equity trade-offs, the menu itself is part of the negotiation; some CEOs are hoping you take the equity-heavy option. For the equity mechanics behind all this, The Skip's episode with Goodwin Procter's compensation lawyers is <a href="https://www.youtube.com/watch?v=qQMXR9N08a0">a solid deep dive</a>, and Nikhyl Singhal's <a href="https://www.youtube.com/watch?v=8wgI3NHXKKw">insider's guide to tech compensation</a> covers how bands and levels really work inside big companies.</p>
 
@@ -577,6 +602,8 @@ footer p { color: var(--muted); font-size: 14px; }
 
 <p>Budget, headcount, training, scope: tie the asks to the job mission you and the hiring manager already agreed on. He tells the story of a CPO who asked for $20M for tech debt in the negotiation, got it on day one, and got promoted within a year partly because she started with the resources to win. Then, for the money itself, his phrasing is deliberately plain (1:01:01): "Are you open to 450? That was really what I was hoping for. Is that something we can talk about?" Most of the time, they say yes.</p>
 
+<p>Two habits keep the close collaborative when the base truly won't move. First, Belcak's trading rule: never accept a concession without asking for something back. <em>"I understand the base is fixed. Would we be able to make up the difference in the bonus? That way you only pay me if I meet or exceed expectations."</em> A performance bonus takes risk off the company, which is why it's the easiest yes in the room, and the same shape works for a continuing-education budget, extra PTO, a later start date, or a standing quarterly 1:1 with your skip-level. Second, walk in with three versions of the deal already gamed out: Plan A leads with the item you value most, Plan B makes up for losing that item with the others, and Plan C hits the same total through a different mix. When the recruiter says no to A, you're not improvising; you're presenting B.</p>
+
 <h2 id="stage-5-protect-the-close">Stage 5: Protect the close</h2>
 
 <p>Deals lose money at the paperwork stage. Warwick tells the story of a CRO whose written severance came back at half the discussed number. The recovery script was four words:</p>
@@ -598,11 +625,15 @@ footer p { color: var(--muted); font-size: 14px; }
   <h4>Copy these</h4>
   <ul>
     <li><strong>Recruiter screen:</strong> "I don't talk about compensation until we're ready to make an offer. Is that going to be a problem?"</li>
+    <li><strong>Screen won't proceed without a number:</strong> "Since you seem to have a range in mind, would you be open to sharing the range you've budgeted for this role?"</li>
+    <li><strong>Forced to name a range:</strong> "I'm currently being considered for roles in the range of X to Y, but my number one priority is finding the right fit." (Your real target goes at the bottom of the range.)</li>
     <li><strong>Offer arrives:</strong> "What's the chance there's a little bit more?"</li>
     <li><strong>Light offer:</strong> "I have to be honest, where this offer stands I don't feel comfortable moving forward. It's a little lighter than I expected." Then silence.</li>
     <li><strong>Re-level the role:</strong> "I'm likely a little more horsepower than you anticipated. What's the chance we can restructure the comp for the type of talent we're bringing in?"</li>
+    <li><strong>Anchored low earlier:</strong> "When I shared that number, it was based on our first conversation. Given what I've learned about the scope, I believe this number better aligns with the value I'd bring."</li>
     <li><strong>Before the money:</strong> "I want to talk about money, but first I want to talk about what will set me up to succeed in this role."</li>
     <li><strong>The ask:</strong> "Are you open to 450? That's what I was hoping for. Is that something we can talk about?"</li>
+    <li><strong>Base is capped:</strong> "I understand the base is fixed. Would we be able to make up the difference in the bonus? That way you only pay me if I meet or exceed expectations."</li>
     <li><strong>Paperwork discrepancy:</strong> "Was that a mistake?"</li>
   </ul>
 </div>
@@ -616,6 +647,13 @@ footer p { color: var(--muted); font-size: 14px; }
     <li>The Skip Podcast: <a href="https://www.youtube.com/watch?v=8wgI3NHXKKw">The Insider's Guide to Tech Compensation, Negotiation, and Career Growth</a> (Jan 2025)</li>
     <li>The Skip Podcast: <a href="https://www.youtube.com/watch?v=qQMXR9N08a0">Explaining Equity and Executive Compensation, with Goodwin Procter</a> (Feb 2023)</li>
     <li>The Mochary Method curriculum: <a href="https://docs.google.com/document/d/1EnMXBO0uum5E5x6QlMcbcdOIRightwdy73DzRerKTdI/edit">compensation formulas</a> and <a href="https://docs.google.com/document/d/1iK7OMMBbmvpzwfsumKde2tbO3MFLSSDU715-Yv3oOOA/edit">the anti-sell</a></li>
+    <li>The Dream Job System (Austin Belcak): <a href="https://podcasts.apple.com/us/podcast/4-takeaways-from-surveying-115k-people-on-salary-negotiation/id1542564331?i=1000723676975">4 Takeaways From Surveying 115K+ People On Salary Negotiation</a> (Aug 2025)</li>
+    <li>The Dream Job System (Austin Belcak): <a href="https://podcasts.apple.com/us/podcast/skipping-this-could-cost-you-%24500k-in-salary-ep-759/id1542564331?i=1000730767657">Skipping This Could Cost You $500k+ In Salary</a> (Oct 2025)</li>
+    <li>The Dream Job System (Austin Belcak): <a href="https://podcasts.apple.com/us/podcast/why-you-wont-lose-an-offer-by-negotiating-your-salary-ep-180/id1542564331?i=1000548787168">Why You Won't Lose An Offer By Negotiating Your Salary</a> (Jan 2022)</li>
+    <li>The Dream Job System (Austin Belcak): <a href="https://podcasts.apple.com/us/podcast/3-steps-to-negotiating-salary-in-an-interview-ep-634/id1542564331?i=1000681075233">3 Steps To Negotiating Salary In An Interview</a> (Dec 2024)</li>
+    <li>The Dream Job System (Austin Belcak): <a href="https://podcasts.apple.com/us/podcast/my-3-part-answer-to-what-are-your-salary-expectations-ep-807/id1542564331?i=1000748492051">My 3 Part Answer To "What Are Your Salary Expectations?"</a> (Feb 2026)</li>
+    <li>The Dream Job System (Austin Belcak): <a href="https://podcasts.apple.com/us/podcast/how-to-negotiate-after-sharing-a-low-number-ep-733/id1542564331?i=1000721154420">How To Negotiate After Sharing A Low Number</a> (Aug 2025)</li>
+    <li>The Dream Job System (Austin Belcak): <a href="https://podcasts.apple.com/us/podcast/11-things-you-can-negotiate-besides-salary-ep-233/id1542564331?i=1000564140623">11 Things You Can Negotiate Besides Salary</a> (May 2022)</li>
   </ul>
 </div>
 

--- a/playbooks/stay-confident-after-job-rejection.html
+++ b/playbooks/stay-confident-after-job-rejection.html
@@ -419,7 +419,7 @@ footer p { color: var(--muted); font-size: 14px; }
   <div class="post-kicker">Job Search</div>
   <h1>How to stay confident when your job search is full of rejection</h1>
   <p class="post-sub">Most of what a job search sends back is silence and no. Here's how to read those rejections accurately and keep showing up strong.</p>
-  <div class="post-meta">10 min read</div>
+  <div class="post-meta">11 min read</div>
 </div>
 
 <main class="layout">
@@ -472,6 +472,29 @@ footer p { color: var(--muted); font-size: 14px; }
     <li>Whether the next company will decide the same way.</li>
     <li>Anything at all, until you compare it with your other interviews and look for a repeat.</li>
   </ul>
+</div>
+
+<p>The fastest way to stop reading a rejection as a verdict is to price it in before it happens. Austin Belcak, who coaches job seekers at Cultivated Culture, treats the search as a funnel where each stage converts at roughly 30 percent, his observed average across clients. Work backward from two offers and the volume of no is already on the page before you send a single application.</p>
+
+<div class="callout">
+  <h4>Belcak's funnel math</h4>
+  <ul>
+    <li>2 offers ← 6 final rounds</li>
+    <li>6 final rounds ← roughly 18 phone screens</li>
+    <li>18 phone screens ← roughly 54 real conversations</li>
+    <li>54 conversations ← roughly 162 people contacted</li>
+  </ul>
+</div>
+
+<p>Written that way, the search <em>is</em> 160 people telling you no in various ways, and the two offers still arrive. A rejection at any stage is the 70 percent doing what the 70 percent does. Track your own rates per stage and the number stops being emotional at all, because it becomes the step where your funnel needs work.</p>
+
+<div class="nugget">
+  <p class="nugget-lead"><strong>The Dream Job System: the funnel technique.</strong> This one is audio only. The quote is at 5:26; the player starts from the top, or <a href="https://podcasts.apple.com/us/podcast/statistically-guarantee-an-offer-with-the-funnel/id1542564331?i=1000713055878&t=326">open it on Apple Podcasts cued to 5:26</a>.</p>
+  <blockquote>"Hey, this funnel starts with 162 networking emails. That's where I'm going to start. Or this funnel starts with 162 online applications, whatever that is for you. But then you're going to start optimizing."</blockquote>
+  <div class="nugget-who"><strong>Austin Belcak</strong>, Cultivated Culture · The Dream Job System</div>
+  <div class="audio-embed">
+    <iframe src="https://embed.podcasts.apple.com/us/podcast/statistically-guarantee-an-offer-with-the-funnel/id1542564331?i=1000713055878&theme=auto" height="175" frameborder="0" sandbox="allow-forms allow-popups allow-same-origin allow-scripts allow-top-navigation-by-user-activation" allow="autoplay *; encrypted-media *; clipboard-write" loading="lazy" title="The Dream Job System: Statistically Guarantee An Offer With The &quot;Funnel Technique&quot; - Apple Podcasts"></iframe>
+  </div>
 </div>
 
 <h2 id="debrief-every-interview-win-or-lose">Debrief every interview, win or lose</h2>
@@ -537,6 +560,8 @@ footer p { color: var(--muted); font-size: 14px; }
 </div>
 
 <p>Managing that balance sheet is mostly routine. Treat the search as a part-time job with set hours, roughly 20 to 25 a week, and close the laptop when the hours are done, because a search that runs all day produces the same output with triple the anxiety. Measure your week by what you controlled, applications sent and conversations held, rather than by offers. Keep one activity in your week that you're plainly good at, whether that's mentoring, a side project, or a sport, so the search isn't the only place anyone sees you be good at something. And protect sleep and exercise the way you would before a big presentation, because interviews are performances and you're doing them weekly.</p>
+
+<p>If you're searching full time, Belcak prescribes an explicit daily allocation: four to six hours of real search work, two hours of self-care, and two hours on a hobby. The hobby is load-bearing, not decoration. Work provided identity and progress, and the search doesn't, so something else has to. His point about the marginal hour is worth holding onto: a seventh hour of applications won't make an offer arrive sooner, but it will make you worse in the interviews that matter.</p>
 
 <p>Nikhyl Singhal spent an episode of The Skip coaching a design leader whose confidence had cratered after a few months of searching. His advice starts with pacing: treat the gap like an athlete's off-season, with deliberate recovery and skill work, and set your expectations for a long season. He also names the trap most people fall into in week one.</p>
 
@@ -627,6 +652,8 @@ footer p { color: var(--muted); font-size: 14px; }
     <li>Lenny's Podcast: <a href="https://www.youtube.com/watch?v=MajB5CQUKDA">Succeeding as an introvert and PM'ing your career like a product, with Deb Liu</a> (Aug 2024)</li>
     <li>The Skip: <a href="https://www.youtube.com/watch?v=yvsA3QgWyMQ">Battling job search anxiety, with Nikhyl Singhal</a> (Jun 2024)</li>
     <li>WorkLife with Adam Grant: Bouncing Back from Rejection (Apr 2019, audio)</li>
+    <li>The Dream Job System (Austin Belcak): <a href="https://podcasts.apple.com/us/podcast/statistically-guarantee-an-offer-with-the-funnel/id1542564331?i=1000713055878">Statistically Guarantee An Offer With The "Funnel Technique"</a> (Jun 2025)</li>
+    <li>The Dream Job System (Austin Belcak): <a href="https://podcasts.apple.com/us/podcast/3-steps-to-take-if-youve-been-laid-off-ep-152/id1542564331?i=1000542182374">3 Steps To Take If You've Been Laid Off</a> (Nov 2021)</li>
   </ul>
 </div>
 

--- a/playbooks/using-ai-in-your-job-search.html
+++ b/playbooks/using-ai-in-your-job-search.html
@@ -609,6 +609,27 @@ footer p { color: var(--muted); font-size: 14px; }
 
 <p>A grammatically perfect specimen is what a recruiter has already read many times that morning. Write the first draft yourself, badly if necessary, then use AI to tighten it, then put your own irregularities back in. Anthropic's own candidate guidance describes the same order of operations: first draft yourself, then refine.</p>
 
+<p>The difference between AI resume slop and AI leverage is whether you feed the model a standard to hit. Austin Belcak, who coaches job seekers at Cultivated Culture, gives ChatGPT the bullet formula his team validated across thousands of resumes, 12 to 20 words, heavy on role keywords, one or two metrics, and a strong verb, and then works in passes rather than accepting the first draft.</p>
+
+<div class="callout">
+  <h4>Two moves that beat "improve my resume"</h4>
+  <ul>
+    <li><em>"Rewrite this bullet to be under 20 words, include keywords from the job description, include metrics from my resume, and use compelling language."</em></li>
+    <li>Ask for 10 to 20 variations of the same bullet and splice the best fragments. The tenth variant often has the verb and the third has the metric framing.</li>
+  </ul>
+</div>
+
+<div class="nugget">
+  <p class="nugget-lead"><strong>The Dream Job System: AI does the baseline, you do the last mile.</strong> This one is audio only. The quote is at 5:57; the player starts from the top, or <a href="https://podcasts.apple.com/us/podcast/7-ways-chatgpt-can-transform-your-resume-ep-791/id1542564331?i=1000742283232&t=357">open it on Apple Podcasts cued to 5:57</a>.</p>
+  <blockquote>"We want to leverage ChatGPT to do 80% of that baseline work that is really tedious and takes up a lot of our brain power. And we want to save the last 20% for ourselves."</blockquote>
+  <div class="nugget-who"><strong>Austin Belcak</strong>, Cultivated Culture · The Dream Job System</div>
+  <div class="audio-embed">
+    <iframe src="https://embed.podcasts.apple.com/us/podcast/7-ways-chatgpt-can-transform-your-resume-ep-791/id1542564331?i=1000742283232&theme=auto" height="175" frameborder="0" sandbox="allow-forms allow-popups allow-same-origin allow-scripts allow-top-navigation-by-user-activation" allow="autoplay *; encrypted-media *; clipboard-write" loading="lazy" title="The Dream Job System: 7 Ways ChatGPT Can Transform Your Resume - Apple Podcasts"></iframe>
+  </div>
+</div>
+
+<p>That last 20 percent is accuracy to your actual record, and whether every claim survives a follow-up question in an interview, because you're the one who'll be asked.</p>
+
 <p>Cover letters are worth writing only when the application asks for one, and then only if you have something specific. Take-home instructions are binding, including the ones about AI and the ones about time limits, and interviewers do notice when you ignore them.</p>
 
 <div class="callout">
@@ -962,6 +983,8 @@ footer p { color: var(--muted); font-size: 14px; }
     <li>SHRM: 2025 Talent Trends (n=2,040)</li>
     <li>Pew Research Center: Salary negotiation survey (Feb 2023, n=5,188)</li>
     <li>Resume Genius: Salary negotiation survey (1,000 US full-time workers, Pollfish)</li>
+    <li>The Dream Job System (Austin Belcak): <a href="https://podcasts.apple.com/us/podcast/7-ways-chatgpt-can-transform-your-resume-ep-791/id1542564331?i=1000742283232">7 Ways ChatGPT Can Transform Your Resume</a> (Dec 2025)</li>
+    <li>The Dream Job System (Austin Belcak): <a href="https://podcasts.apple.com/us/podcast/the-5-point-checklist-for-job-winning-resume-bullets-ep-799/id1542564331?i=1000744411057">The 5 Point Checklist For Job-Winning Resume Bullets</a> (Jan 2026)</li>
   </ul>
 </div>
 

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -175,6 +175,12 @@
     <priority>0.7</priority>
   </url>
   <url>
+    <loc>https://work.coach/playbooks/how-to-get-360-feedback</loc>
+    <lastmod>2026-08-13</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
     <loc>https://work.coach/playbooks/give-feedback-that-lands</loc>
     <lastmod>2026-07-20</lastmod>
     <changefreq>monthly</changefreq>


### PR DESCRIPTION
## Summary

- Weaves frameworks, scripts, and stats from The Dream Job System podcast (Austin Belcak) into 15 existing playbooks, each addition placed in the page's existing sections with timestamp-cued Apple Podcasts embeds and per-episode linked Sources entries in house format
- Adds a new playbook, **How to get 360 feedback, with or without the official process** (`/playbooks/how-to-get-360-feedback`), sourced across six shows — Lenny's Podcast (Kim Scott, Jules Walter, Elizabeth Stone), Level Up (Ethan Evans), WorkLife with Adam Grant (Ray Dalio, Mellody Hobson), Mochary Method (Wade Foster), Delivering Value (Samantha Leal, Liz Christo), and Product Therapy — with five YouTube and two Apple embeds cued to verified timestamps
- Wires the new page into the playbooks index (count updated 59 → 60 across all metadata), `sitemap.xml`, and the honest-feedback page's cluster nav
- Includes one unrelated one-liner: shortens the 404 page's download button label (separate commit)

## Editorial notes

- All additions went through two external review rounds; the batch was pruned accordingly (a templated Glassdoor paragraph was removed from the four company guides, an off-topic insertion removed from the tell-me-about-yourself page, tone softened in several places, duplicated tactics converted to cross-links)
- The salary, resume-bullets, foot-in-the-door, and referral pages carry the largest additions; four pages touched mid-process were fully restored to baseline
- Sources cite the exact episode airings the embeds link to; timestamps were located in local transcripts and cross-checked against the linked cut

## Test plan

- [x] Tag-balance validation across all 21 changed HTML files
- [x] All Apple/YouTube embed URLs resolve (HTTP 200 spot checks)
- [x] `git diff --check` clean
- [ ] Visual pass on the local server (`python3 -m http.server`), especially `/playbooks/salary-negotiation-scripts.html` and `/playbooks/how-to-get-360-feedback.html`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CjE8g4EbqYQG9oxwDrmUsP